### PR TITLE
[EN-2285] Update telephone number time of day to default to Both when N/A is toggled

### DIFF
--- a/src/components/Form/Telephone/Telephone.jsx
+++ b/src/components/Form/Telephone/Telephone.jsx
@@ -148,7 +148,7 @@ export default class Telephone extends ValidationElement {
     }, () => {
       this.update({
         noNumber: !this.props.noNumber,
-        timeOfDay: '',
+        timeOfDay: this.props.noNumber ? 'Both' : '',
         numberType: '',
         extension: '',
       })


### PR DESCRIPTION
This PR updated the telephone number time of day to default to `Both` when `Not applicable is toggled. Before, when `Not applicable` it toggled on and off, the time of day was erased and the default value wasn't getting selected again. This makes sure the default value is selected again.

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)