### PR TITLE
[EN-3878] Remove link for unnecessary google fonts

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -54,9 +54,6 @@
       <script type="text/javascript" src="/html5shiv.min.js"></script>
       <script type="text/javascript" src="/respond.min.js"></script>
     <![endif]-->
-    <link
-      href="https://fonts.googleapis.com/css?family=Merriweather:700|Source+Sans+Pro:400,700"
-      rel="stylesheet">
   </head>
   <body>
     <table class="print-table">


### PR DESCRIPTION
## Description
This PR removes the dependencies hosted by 3rd parties for reasons mentioned in `EN-3878`.

We don't actually need to import the font faces ourselves because they are included in the USWDS styles we use. See [here](https://github.com/uswds/uswds/tree/develop/src/fonts)

Please confirm that everything looks as expected and `Merriweather` and `Source Sans Pro` fonts are still being used.

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
