### PR TITLE
[EN-3104] Update domestic phone numbers so they can't start with 

### DIFF
--- a/src/components/Form/Telephone/Telephone.jsx
+++ b/src/components/Form/Telephone/Telephone.jsx
@@ -325,7 +325,7 @@ export default class Telephone extends ValidationElement {
               ariaLabel={i18n.t('telephone.aria.domesticAreaCode')}
               disabled={this.props.noNumber}
               maxlength="3"
-              pattern="\d{3}"
+              pattern="^((?!(0))\d{3})"
               prefilter={digitsOnly}
               readonly={this.props.readonly}
               required={this.required('Domestic')}

--- a/src/config/locales/en/error.js
+++ b/src/config/locales/en/error.js
@@ -979,13 +979,13 @@ export const error = {
         pattern: {
           title: 'There is a problem with the area code',
           message:
-            'The area code should be 3 numbers long and between 0 and 9.',
+            'The area code should be 3 numbers long and between 1 and 9.',
           note: '',
         },
         length: {
           title: 'There is a problem with the area code',
           message:
-            'The area code should be 3 numbers long and between 0 and 9.',
+            'The area code should be 3 numbers long and between 1 and 9.',
           note: '',
         },
         required: {

--- a/src/config/locales/en/error.js
+++ b/src/config/locales/en/error.js
@@ -979,13 +979,13 @@ export const error = {
         pattern: {
           title: 'There is a problem with the area code',
           message:
-            'The area code should be 3 numbers long and between 1 and 9.',
+            'The area code should be 3 numbers long, between 0 and 9, and cannot begin with 0.',
           note: '',
         },
         length: {
           title: 'There is a problem with the area code',
           message:
-            'The area code should be 3 numbers long and between 1 and 9.',
+            'The area code should be 3 numbers long, between 0 and 9, and cannot begin with 0.',
           note: '',
         },
         required: {

--- a/src/models/shared/phone.js
+++ b/src/models/shared/phone.js
@@ -33,7 +33,7 @@ const phone = {
       case 'Domestic':
         return {
           presence: true,
-          format: { pattern: /^\d{10}$/ },
+          format: { pattern: /^((?!(0))[0-9]{10})$/ },
         }
       case 'DSN':
         return {


### PR DESCRIPTION
#  Description
This PR updates the United States (domestic) phone number field so that the phone number cannot start with 0. This also makes a small revision to the error locale so that it makes sense. However that text should be confirmed and approved.

This ONLY focuses on the United States (domestic) phone number as presented in `EN-3104`.
## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)