### PR TITLE
Fix miscellaneous validation errors

### DIFF
--- a/src/components/Section/Military/History/MilitaryService.jsx
+++ b/src/components/Section/Military/History/MilitaryService.jsx
@@ -52,7 +52,10 @@ export default class MilitaryService extends ValidationElement {
 
   updateService(values) {
     this.update({
-      Service: values
+      Service: values,
+      ServiceState: ['AirNationalGuard', 'ArmyNationalGuard'].includes(values.value)
+        ? this.props.ServiceState
+        : {}
     })
   }
 

--- a/src/components/Section/Package/Comments/index.jsx
+++ b/src/components/Section/Package/Comments/index.jsx
@@ -21,7 +21,7 @@ const sectionConfig = {
 
 const PackageComments = (props) => {
   const {
-    HasComments, Comments, required, dispatch, location,
+    HasComments, Comments, required, dispatch, location, formType,
   } = props
 
   const updateBranch = (values) => {
@@ -38,7 +38,7 @@ const PackageComments = (props) => {
       validateSection({
         data: { HasComments, Comments, ...updatedValues },
         key: sectionConfig.key,
-      }) === true
+      }, formType) === true
     ))
   }
 
@@ -56,7 +56,7 @@ const PackageComments = (props) => {
       validateSection({
         data: { HasComments, Comments, ...updatedValues },
         key: sectionConfig.key,
-      }) === true
+      }, formType) === true
     ))
   }
 
@@ -105,6 +105,7 @@ PackageComments.propTypes = {
   required: PropTypes.bool,
   dispatch: PropTypes.func,
   location: PropTypes.object,
+  formType: PropTypes.string,
 }
 
 PackageComments.defaultProps = {
@@ -113,6 +114,7 @@ PackageComments.defaultProps = {
   required: false,
   dispatch: () => {},
   location: {},
+  formType: '',
 }
 
 const mapStateToProps = (state) => {
@@ -123,6 +125,7 @@ const mapStateToProps = (state) => {
   return {
     HasComments: Comments.HasComments,
     Comments: Comments.Comments,
+    formType: application.Settings.formType,
   }
 }
 

--- a/src/models/__tests__/militaryService.test.js
+++ b/src/models/__tests__/militaryService.test.js
@@ -79,19 +79,6 @@ describe('The military service model', () => {
       .toEqual(expect.arrayContaining(expectedErrors))
   })
 
-  describe('if Service is not National Guard', () => {
-    it('ServiceState must be empty', () => {
-      const testData = {
-        Service: { value: 'Army' },
-        ServiceState: { value: 'MA' },
-      }
-      const expectedErrors = ['ServiceState.requireEmpty.VALUE_NOT_EMPTY']
-
-      expect(validateModel(testData, militaryService))
-        .toEqual(expect.arrayContaining(expectedErrors))
-    })
-  })
-
   it('requires HasBeenDischarged to be filled', () => {
     const testData = {
       HasBeenDischarged: {

--- a/src/models/employment.js
+++ b/src/models/employment.js
@@ -44,23 +44,6 @@ const supervisor = {
     return { presence: true, model: { validator: email } }
   },
   Address: { presence: true, location: { validator: address } },
-  AlternateAddress: (value, attributes) => {
-    if (attributes.Address && isInternational(attributes.Address)) {
-      return {
-        presence: true,
-        model: { validator: physicalAddress, militaryAddress: true },
-      }
-    }
-
-    if (attributes.Address && isPO(attributes.Address)) {
-      return {
-        presence: true,
-        model: { validator: physicalAddress, militaryAddress: false },
-      }
-    }
-
-    return {}
-  },
   Telephone: { presence: true, model: { validator: phone, requireNumber: true } },
 }
 
@@ -311,6 +294,23 @@ const employment = {
     }
 
     if (attributes.ReferenceAddress && isPO(attributes.ReferenceAddress)) {
+      return {
+        presence: true,
+        model: { validator: physicalAddress, militaryAddress: false },
+      }
+    }
+
+    return {}
+  },
+  SupervisorAlternateAddress: (value, attributes) => {
+    if (attributes.Address && isInternational(attributes.Address)) {
+      return {
+        presence: true,
+        model: { validator: physicalAddress, militaryAddress: true },
+      }
+    }
+
+    if (attributes.Address && isPO(attributes.Address)) {
       return {
         presence: true,
         model: { validator: physicalAddress, militaryAddress: false },

--- a/src/models/employment.js
+++ b/src/models/employment.js
@@ -303,14 +303,22 @@ const employment = {
     return {}
   },
   SupervisorAlternateAddress: (value, attributes) => {
-    if (attributes.Address && isInternational(attributes.Address)) {
+    if (
+      attributes.Supervisor
+      && attributes.Supervisor.Address
+      && isInternational(attributes.Supervisor.Address)
+    ) {
       return {
         presence: true,
         model: { validator: physicalAddress, militaryAddress: true },
       }
     }
 
-    if (attributes.Address && isPO(attributes.Address)) {
+    if (
+      attributes.Supervisor
+      && attributes.Supervisor.Address
+      && isPO(attributes.Supervisor.Address)
+    ) {
       return {
         presence: true,
         model: { validator: physicalAddress, militaryAddress: false },

--- a/src/models/militaryService.js
+++ b/src/models/militaryService.js
@@ -46,7 +46,7 @@ const militaryService = {
       }
     }
 
-    return {}
+    return { requireEmpty: true }
   },
   HasBeenDischarged: {
     presence: true,

--- a/src/models/militaryService.js
+++ b/src/models/militaryService.js
@@ -46,7 +46,7 @@ const militaryService = {
       }
     }
 
-    return { requireEmpty: true }
+    return {}
   },
   HasBeenDischarged: {
     presence: true,

--- a/src/models/shared/__tests__/sentence.test.js
+++ b/src/models/shared/__tests__/sentence.test.js
@@ -63,20 +63,6 @@ describe('The sentence model', () => {
   })
 
   describe('if ExceedsYear is "Yes"', () => {
-    it('IncarcerationDates must cover a duration greater than a year', () => {
-      const testData = {
-        ExceedsYear: { value: 'Yes' },
-        IncarcerationDates: {
-          from: { day: 5, month: 5, year: 2000 },
-          to: { day: 2, month: 8, year: 2000 },
-        },
-      }
-      const expectedErrors = ['IncarcerationDates.daterange.DATE_RANGE_TOO_SHORT']
-
-      expect(validateModel(testData, sentence))
-        .toEqual(expect.arrayContaining(expectedErrors))
-    })
-
     it('passes a valid sentence', () => {
       const testData = {
         Description: { value: 'Something' },
@@ -97,20 +83,6 @@ describe('The sentence model', () => {
   })
 
   describe('if ExceedsYear is "No"', () => {
-    it('IncarcerationDates must cover a duration less than or equal to one year', () => {
-      const testData = {
-        ExceedsYear: { value: 'No' },
-        IncarcerationDates: {
-          from: { day: 5, month: 5, year: 2000 },
-          to: { day: 2, month: 8, year: 2001 },
-        },
-      }
-      const expectedErrors = ['IncarcerationDates.daterange.DATE_RANGE_TOO_LONG']
-
-      expect(validateModel(testData, sentence))
-        .toEqual(expect.arrayContaining(expectedErrors))
-    })
-
     it('passes a valid sentence', () => {
       const testData = {
         Description: { value: 'Something' },
@@ -122,11 +94,43 @@ describe('The sentence model', () => {
         },
         IncarcerationDates: {
           from: { day: 5, month: 5, year: 2000 },
-          to: { day: 2, month: 8, year: 2000 },
+          to: { day: 5, month: 5, year: 2001 },
         },
       }
 
       expect(validateModel(testData, sentence)).toEqual(true)
+    })
+  })
+
+  describe('if Incarcerated is "Yes"', () => {
+    it('IncarcerationDates must cover a duration greater than a year', () => {
+      const testData = {
+        Incarcerated: { value: 'Yes' },
+        IncarcerationDates: {
+          from: { day: 5, month: 5, year: 2000 },
+          to: { day: 2, month: 8, year: 2000 },
+        },
+      }
+      const expectedErrors = ['IncarcerationDates.daterange.DATE_RANGE_TOO_SHORT']
+
+      expect(validateModel(testData, sentence))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+  })
+
+  describe('if Incarcerated is "No"', () => {
+    it('IncarcerationDates must cover a duration less than or equal to one year', () => {
+      const testData = {
+        Incarcerated: { value: 'No' },
+        IncarcerationDates: {
+          from: { day: 5, month: 5, year: 2000 },
+          to: { day: 2, month: 8, year: 2001 },
+        },
+      }
+      const expectedErrors = ['IncarcerationDates.daterange.DATE_RANGE_TOO_LONG']
+
+      expect(validateModel(testData, sentence))
+        .toEqual(expect.arrayContaining(expectedErrors))
     })
   })
 
@@ -164,8 +168,8 @@ describe('The sentence model', () => {
         to: { year: 2013, month: 10, day: 1 },
       },
       IncarcerationDates: {
-        from: { year: 1995, month: 2, day: 10 },
-        to: { year: 1995, month: 10, day: 1 },
+        from: { year: 1995, month: 10, day: 10 },
+        to: { year: 1996, month: 10, day: 10 },
       },
     }
 

--- a/src/models/shared/sentence.js
+++ b/src/models/shared/sentence.js
@@ -27,9 +27,9 @@ const sentence = {
     }
 
     const daterangeOptions = {}
-    if (attributes.ExceedsYear && attributes.ExceedsYear.value === 'Yes') {
+    if (attributes.Incarcerated && attributes.Incarcerated.value === 'Yes') {
       daterangeOptions.minDuration = { years: 1 }
-    } else if (attributes.ExceedsYear && attributes.ExceedsYear.value === 'No') {
+    } else if (attributes.Incarcerated && attributes.Incarcerated.value === 'No') {
       daterangeOptions.maxDuration = { years: 1 }
     }
 

--- a/src/sagas/form.js
+++ b/src/sagas/form.js
@@ -75,7 +75,7 @@ export function* handleSubsectionUpdate({ key, data }) {
   // This because currently, data is updated a whole subsection at a time
   // Consider changing to updateSectionData for field-level updates in the future
   const newData = { ...formSection.data, ...data }
-  const errors = yield call(validateSection, { key, data: newData, formType })
+  const errors = yield call(validateSection, { key, data: newData }, formType)
 
   const newFormSection = {
     data: newData,

--- a/src/sagas/form.test.js
+++ b/src/sagas/form.test.js
@@ -157,8 +157,7 @@ describe('The handleSubsectionUpdate saga', () => {
       .toEqual(call(validateSection, {
         key: 'IDENTIFICATION_NAME',
         data: newState,
-        formType: 'SF-86',
-      }))
+      }, 'SF-86'))
   })
 
   it('dispatches the new section data', () => {

--- a/src/views/Form/Form.jsx
+++ b/src/views/Form/Form.jsx
@@ -110,7 +110,7 @@ class Form extends React.Component {
       <div id="eapp-form" className="eapp-form">
         <div id="info">
           <Section section={params.section} subsection={subsection} />
-          <SavedIndicator interval="30000" />
+          <SavedIndicator interval={30000} />
           {showSessionWarning && <TimeoutWarning timeout={env.SessionTimeout()} />}
         </div>
       </div>


### PR DESCRIPTION
## Description
The are a handful of validation errors that came up while reviewing the complete scenario test data. I had started working on these prior to our audit of the test cases , so these fixes will be bundled, but any others should be split based on their tickets in JIRA.

1. Employment. For an employment item, the supervisor's alternate address isn't actually inside of the nested supervisor model. It is labeled as `SupervisorAlternateAddress` in the `employment` model. I just moved it outside of `supervisor` and into `employment`.

2. Additional Comments - I added the formType to the `validateSection` because it's an expected argument. I don't expect any errors without the `formType`. Adding the `formType` just gives additional peace of mind.

3. Legal -> Police -> Offenses (Validation Matrix 22.8.3) - In this section, there was an issue related to incarcerations/sentences. The date range had an inaccurate validation for the question `If the conviction resulted in imprisonment, provide the dates that you actually were incarcerated`.

4, Military Service (ServiceState) - `ServiceState` is only required for certain service values. For those that don't require it, we had a validation enforcing that `ServiceState` is empty. However, eApp saves empty values for that fields, so it can't be validated like that. For now, I got rid of the validation that enforces it to be empty. Alternatively, we can tweak the validation to check for empty values in an object.

Previously it was checking the yes/no for `Were you sentenced to imprisonment for a term exceeding 1 year?`, but it should be checking the yes/no for `Were you incarcerated as a result of that sentence for not less than 1 year?`.

This is the error from e-QIP:
```
WARN[0005] gov.opm.eqip.ws.webservice.ApplicantDataException: SF86_5_S22-PoliceRecord: You have answered 'Yes' to 'Were you incarcerated as a result of that sentence for not less than 1 year?' Dates of incarceration must be at least one year.
```

Misc Fixes:
- Update `SavedIndicator` interval prop type to be a number instead of a string to satisfy prop type error

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)