### PR TITLE
[EN-3914] Fix AlternateAddress Telephone validation

### DIFF
--- a/src/models/civilUnion.js
+++ b/src/models/civilUnion.js
@@ -65,14 +65,22 @@ const civilUnion = {
     if (attributes.Address && isInternational(attributes.Address)) {
       return {
         presence: true,
-        model: { validator: physicalAddress, militaryAddress: true },
+        model: {
+          validator: physicalAddress,
+          militaryAddress: true,
+          hasTelephone: false,
+        },
       }
     }
 
     if (attributes.Address && isPO(attributes.Address)) {
       return {
         presence: true,
-        model: { validator: physicalAddress, militaryAddress: false },
+        model: {
+          validator: physicalAddress,
+          militaryAddress: false,
+          hasTelephone: false,
+        },
       }
     }
 

--- a/src/models/employment.js
+++ b/src/models/employment.js
@@ -142,14 +142,22 @@ const employment = {
     if (attributes.Address && isInternational(attributes.Address)) {
       return {
         presence: true,
-        model: { validator: physicalAddress, militaryAddress: true },
+        model: {
+          validator: physicalAddress,
+          militaryAddress: true,
+          hasTelephone: false,
+        },
       }
     }
 
     if (attributes.Address && isPO(attributes.Address)) {
       return {
         presence: true,
-        model: { validator: physicalAddress, militaryAddress: false },
+        model: {
+          validator: physicalAddress,
+          militaryAddress: false,
+          hasTelephone: false,
+        },
       }
     }
 
@@ -230,6 +238,7 @@ const employment = {
         presence: true,
         model: {
           validator: physicalAddress,
+          hasTelephone: true,
         },
       }
     }
@@ -244,14 +253,22 @@ const employment = {
       if (Address && isInternational(Address)) {
         return {
           presence: true,
-          model: { validator: physicalAddress, militaryAddress: true },
+          model: {
+            validator: physicalAddress,
+            militaryAddress: true,
+            hasTelephone: false,
+          },
         }
       }
 
       if (Address && isPO(Address)) {
         return {
           presence: true,
-          model: { validator: physicalAddress, militaryAddress: false },
+          model: {
+            validator: physicalAddress,
+            militaryAddress: false,
+            hasTelephone: false,
+          },
         }
       }
     }
@@ -306,14 +323,22 @@ const employment = {
     if (attributes.ReferenceAddress && isInternational(attributes.ReferenceAddress)) {
       return {
         presence: true,
-        model: { validator: physicalAddress, militaryAddress: true },
+        model: {
+          validator: physicalAddress,
+          militaryAddress: true,
+          hasTelephone: false,
+        },
       }
     }
 
     if (attributes.ReferenceAddress && isPO(attributes.ReferenceAddress)) {
       return {
         presence: true,
-        model: { validator: physicalAddress, militaryAddress: false },
+        model: {
+          validator: physicalAddress,
+          militaryAddress: false,
+          hasTelephone: false,
+        },
       }
     }
 

--- a/src/models/foreignContact.js
+++ b/src/models/foreignContact.js
@@ -149,7 +149,11 @@ const foreignContact = {
   },
   AlternateAddress: {
     presence: true,
-    model: { validator: physicalAddress, militaryAddress: true },
+    model: {
+      validator: physicalAddress,
+      militaryAddress: true,
+      hasTelephone: false,
+    },
   },
   Employer: (value, attributes) => {
     const { EmployerNotApplicable } = attributes

--- a/src/models/relative.js
+++ b/src/models/relative.js
@@ -142,7 +142,11 @@ const relative = {
 
     return {
       presence: true,
-      model: { validator: physicalAddress, militaryAddress: true },
+      model: {
+        validator: physicalAddress,
+        militaryAddress: true,
+        hasTelephone: false,
+      },
     }
   },
   CitizenshipDocumentation: (value, attributes, attributeNane, options) => {

--- a/src/models/residence.js
+++ b/src/models/residence.js
@@ -35,14 +35,24 @@ const residence = {
     if (attributes.Address && isInternational(attributes.Address)) {
       return {
         presence: true,
-        model: { validator: physicalAddress, militaryAddress: true, allowPOBox: false },
+        model: {
+          validator: physicalAddress,
+          militaryAddress: true,
+          allowPOBox: false,
+          hasTelephone: false,
+        },
       }
     }
 
     if (attributes.Address && isPO(attributes.Address)) {
       return {
         presence: true,
-        model: { validator: physicalAddress, militaryAddress: false, allowPOBox: false },
+        model: {
+          validator: physicalAddress,
+          militaryAddress: false,
+          allowPOBox: false,
+          hasTelephone: false,
+        },
       }
     }
 
@@ -151,14 +161,22 @@ const residence = {
     if (attributes.ReferenceAddress && isInternational(attributes.ReferenceAddress)) {
       return {
         presence: true,
-        model: { validator: physicalAddress, militaryAddress: true },
+        model: {
+          validator: physicalAddress,
+          militaryAddress: true,
+          hasTelephone: false,
+        },
       }
     }
 
     if (attributes.ReferenceAddress && isPO(attributes.ReferenceAddress)) {
       return {
         presence: true,
-        model: { validator: physicalAddress, militaryAddress: false },
+        model: {
+          validator: physicalAddress,
+          militaryAddress: false,
+          hasTelephone: false,
+        },
       }
     }
 

--- a/src/models/shared/__tests__/physicalAddress.test.js
+++ b/src/models/shared/__tests__/physicalAddress.test.js
@@ -108,7 +108,7 @@ describe('The PhysicalAddress model', () => {
       const expectedErrors = [
         'Telephone.model.noNumber.inclusion.INCLUSION',
       ]
-      expect(validateModel(testData, physicalAddress))
+      expect(validateModel(testData, physicalAddress, { hasTelephone: true }))
         .toEqual(expect.arrayContaining(expectedErrors))
     })
 
@@ -207,6 +207,68 @@ describe('The PhysicalAddress model', () => {
 
       expect(validateModel(testData, physicalAddress, { militaryAddress: false }))
         .toEqual(true)
+    })
+  })
+
+  describe('with hasTelephone option', () => {
+    it('errors without a telephone number', () => {
+      const options = { hasTelephone: true }
+      const testData = {
+        HasDifferentAddress: { value: 'Yes' },
+        Address: {
+          street: '123 Main ST',
+          city: 'New York',
+          state: 'NY',
+          zipcode: '10003',
+          country: 'United States',
+        },
+        Telephone: {
+          timeOfDay: '',
+          type: '',
+          numberType: '',
+          number: '',
+          extension: '',
+          noNumber: false,
+        },
+      }
+      const expectedErrors = [
+        'Telephone.model.timeOfDay.presence.REQUIRED',
+        'Telephone.model.type.inclusion.INCLUSION',
+        'Telephone.model.number.presence.REQUIRED',
+      ]
+      expect(validateModel(testData, physicalAddress, options))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+  })
+
+  describe('without hasTelephone option', () => {
+    it('does not have errors without a telephone number', () => {
+      const options = { hasTelephone: false }
+      const testData = {
+        HasDifferentAddress: { value: 'Yes' },
+        Address: {
+          street: '123 Main ST',
+          city: 'New York',
+          state: 'NY',
+          zipcode: '10003',
+          country: 'United States',
+        },
+        Telephone: {
+          timeOfDay: '',
+          type: '',
+          numberType: '',
+          number: '',
+          extension: '',
+          noNumber: false,
+        },
+      }
+      const expectedErrors = [
+        'Telephone.model.timeOfDay.presence.REQUIRED',
+        'Telephone.model.type.inclusion.INCLUSION',
+        'Telephone.model.number.presence.REQUIRED',
+      ]
+      expect(validateModel(testData, physicalAddress, options))
+        .toEqual(expect.not.arrayContaining(expectedErrors))
     })
   })
 })

--- a/src/models/shared/physicalAddress.js
+++ b/src/models/shared/physicalAddress.js
@@ -22,14 +22,18 @@ const physicalAddress = {
 
     return {}
   },
-  Telephone: (value, attributes = {}) => {
+  Telephone: (value, attributes = {}, attributeName, options) => {
     const { HasDifferentAddress } = attributes
-    if (HasDifferentAddress
-      && HasDifferentAddress.value
-      && HasDifferentAddress.value === 'Yes') {
-      return {
-        presence: false, // Telephone is optional
-        model: { validator: phone, requireNumber: true },
+    // Employment is one of the few (if not the only) sections that has
+    // addresses with telephone numbers in the data model.
+    if (options.hasTelephone) {
+      if (HasDifferentAddress
+        && HasDifferentAddress.value
+        && HasDifferentAddress.value === 'Yes') {
+        return {
+          presence: false, // Telephone is optional
+          model: { validator: phone, requireNumber: true },
+        }
       }
     }
 


### PR DESCRIPTION
## Description
For context, for Self Employment, Other Federal, State Government, Federal Contractor, Non Government, and Other employment types, applicants are asked to fill a physical address. This physical address contains a location as well as a phone number.

When we refactored the validations, we used the same model for physical addresses and alternate addresses. They are only _mostly_ the same. Physical addresses in employment have a `Telephone` field that alternate addresses don't.

This PR adds an `option` to allow the `Telephone` validation to be enabled/disabled depending on the use case.

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)