### PR TITLE
[EN-3928] Fix international birthplace bug

### DIFF
--- a/src/models/shared/__tests__/location.test.js
+++ b/src/models/shared/__tests__/location.test.js
@@ -163,7 +163,7 @@ describe('The location model', () => {
   })
 
   describe('for an international address', () => {
-    it('state must be empty', () => {
+    it.skip('state must be empty', () => {
       const testData = { state: 'MA', country: 'Canada' }
       const expectedErrors = ['state.requireEmpty.VALUE_NOT_EMPTY']
 
@@ -171,7 +171,7 @@ describe('The location model', () => {
         .toEqual(expect.arrayContaining(expectedErrors))
     })
 
-    it('zipcode must be empty', () => {
+    it.skip('zipcode must be empty', () => {
       const testData = { zipcode: '10002', country: 'Canada' }
       const expectedErrors = ['zipcode.requireEmpty.VALUE_NOT_EMPTY']
 

--- a/src/models/shared/__tests__/location.test.js
+++ b/src/models/shared/__tests__/location.test.js
@@ -163,6 +163,7 @@ describe('The location model', () => {
   })
 
   describe('for an international address', () => {
+    // Skipped to fix [EN-3928], see comment in models/shared/location.js
     it.skip('state must be empty', () => {
       const testData = { state: 'MA', country: 'Canada' }
       const expectedErrors = ['state.requireEmpty.VALUE_NOT_EMPTY']
@@ -171,6 +172,7 @@ describe('The location model', () => {
         .toEqual(expect.arrayContaining(expectedErrors))
     })
 
+    // Skipped to fix [EN-3928], see comment in models/shared/location.js
     it.skip('zipcode must be empty', () => {
       const testData = { zipcode: '10002', country: 'Canada' }
       const expectedErrors = ['zipcode.requireEmpty.VALUE_NOT_EMPTY']

--- a/src/models/shared/__tests__/name.test.js
+++ b/src/models/shared/__tests__/name.test.js
@@ -48,6 +48,7 @@ describe('The name model', () => {
       .toEqual(expect.arrayContaining(expectedErrors))
   })
 
+  // Skipped to fix [EN-3928], see comment in models/shared/name.js
   it.skip('middle name should be empty if noMiddleName is checked', () => {
     const testData = {
       middle: 'Foo',

--- a/src/models/shared/__tests__/name.test.js
+++ b/src/models/shared/__tests__/name.test.js
@@ -48,7 +48,7 @@ describe('The name model', () => {
       .toEqual(expect.arrayContaining(expectedErrors))
   })
 
-  it('middle name should be empty if noMiddleName is checked', () => {
+  it.skip('middle name should be empty if noMiddleName is checked', () => {
     const testData = {
       middle: 'Foo',
       noMiddleName: true,

--- a/src/models/shared/location.js
+++ b/src/models/shared/location.js
@@ -48,7 +48,7 @@ const location = {
       }
     }
 
-    return { requireEmpty: true }
+    return {}
   },
   zipcode: (value, attributes = {}) => {
     if (!isInternational(attributes)) {
@@ -59,7 +59,7 @@ const location = {
       }
     }
 
-    return { requireEmpty: true }
+    return {}
   },
   country: (value, attributes, attributeName, options) => {
     if (options.militaryAddress === true) {
@@ -83,7 +83,7 @@ const location = {
       return { presence: true }
     }
 
-    return { requireEmpty: true }
+    return {}
   },
 }
 

--- a/src/models/shared/location.js
+++ b/src/models/shared/location.js
@@ -49,6 +49,16 @@ const location = {
     }
 
     return {}
+
+    /**
+     * The requireEmpty constraint was added to force certain fields to have no
+     * value based on certain conditions. However, this broke some test data
+     * since currently some data structures retain dead/unused data when values
+     * are changed. For now all validation constraints are ignored for
+     * irrelevant values, but this can be added back in the future.
+     * See JIRA issue [EN-3928]
+     * */
+    // return { requireEmpty: true }
   },
   zipcode: (value, attributes = {}) => {
     if (!isInternational(attributes)) {
@@ -60,6 +70,16 @@ const location = {
     }
 
     return {}
+
+    /**
+     * The requireEmpty constraint was added to force certain fields to have no
+     * value based on certain conditions. However, this broke some test data
+     * since currently some data structures retain dead/unused data when values
+     * are changed. For now all validation constraints are ignored for
+     * irrelevant values, but this can be added back in the future.
+     * See JIRA issue [EN-3928]
+     * */
+    // return { requireEmpty: true }
   },
   country: (value, attributes, attributeName, options) => {
     if (options.militaryAddress === true) {
@@ -84,6 +104,16 @@ const location = {
     }
 
     return {}
+
+    /**
+     * The requireEmpty constraint was added to force certain fields to have no
+     * value based on certain conditions. However, this broke some test data
+     * since currently some data structures retain dead/unused data when values
+     * are changed. For now all validation constraints are ignored for
+     * irrelevant values, but this can be added back in the future.
+     * See JIRA issue [EN-3928]
+     * */
+    // return { requireEmpty: true }
   },
 }
 

--- a/src/models/shared/locations/__tests__/birthplace.test.js
+++ b/src/models/shared/locations/__tests__/birthplace.test.js
@@ -47,6 +47,7 @@ describe('The location/birthplace model', () => {
     })
   })
 
+  // Skipped to fix [EN-3928], see comment in models/shared/location.js
   describe('for an international address', () => {
     it.skip('state must be empty', () => {
       const testData = { state: 'MA', country: 'Canada' }

--- a/src/models/shared/locations/__tests__/birthplace.test.js
+++ b/src/models/shared/locations/__tests__/birthplace.test.js
@@ -47,8 +47,8 @@ describe('The location/birthplace model', () => {
     })
   })
 
-  // Skipped to fix [EN-3928], see comment in models/shared/location.js
   describe('for an international address', () => {
+    // Skipped to fix [EN-3928], see comment in models/shared/location.js
     it.skip('state must be empty', () => {
       const testData = { state: 'MA', country: 'Canada' }
       const expectedErrors = ['state.requireEmpty.VALUE_NOT_EMPTY']

--- a/src/models/shared/locations/__tests__/birthplace.test.js
+++ b/src/models/shared/locations/__tests__/birthplace.test.js
@@ -48,7 +48,7 @@ describe('The location/birthplace model', () => {
   })
 
   describe('for an international address', () => {
-    it('state must be empty', () => {
+    it.skip('state must be empty', () => {
       const testData = { state: 'MA', country: 'Canada' }
       const expectedErrors = ['state.requireEmpty.VALUE_NOT_EMPTY']
 

--- a/src/models/shared/locations/__tests__/birthplaceWithoutCounty.test.js
+++ b/src/models/shared/locations/__tests__/birthplaceWithoutCounty.test.js
@@ -47,7 +47,7 @@ describe('The location/birthplaceWithoutCounty model', () => {
   })
 
   describe('for an international address', () => {
-    it('state must be empty', () => {
+    it.skip('state must be empty', () => {
       const testData = { state: 'MA', country: 'Canada' }
       const expectedErrors = ['state.requireEmpty.VALUE_NOT_EMPTY']
 

--- a/src/models/shared/locations/__tests__/birthplaceWithoutCounty.test.js
+++ b/src/models/shared/locations/__tests__/birthplaceWithoutCounty.test.js
@@ -47,6 +47,7 @@ describe('The location/birthplaceWithoutCounty model', () => {
   })
 
   describe('for an international address', () => {
+    // Skipped to fix [EN-3928], see comment in models/shared/location.js
     it.skip('state must be empty', () => {
       const testData = { state: 'MA', country: 'Canada' }
       const expectedErrors = ['state.requireEmpty.VALUE_NOT_EMPTY']

--- a/src/models/shared/locations/__tests__/usCityStateZipInternationalCity.test.js
+++ b/src/models/shared/locations/__tests__/usCityStateZipInternationalCity.test.js
@@ -56,7 +56,7 @@ describe('The location/usCityStateZipInternationalCity model', () => {
   })
 
   describe('for an international address', () => {
-    it('state must be empty', () => {
+    it.skip('state must be empty', () => {
       const testData = { state: 'MA', country: 'Canada' }
       const expectedErrors = ['state.requireEmpty.VALUE_NOT_EMPTY']
 

--- a/src/models/shared/locations/__tests__/usCityStateZipInternationalCity.test.js
+++ b/src/models/shared/locations/__tests__/usCityStateZipInternationalCity.test.js
@@ -56,6 +56,7 @@ describe('The location/usCityStateZipInternationalCity model', () => {
   })
 
   describe('for an international address', () => {
+    // Skipped to fix [EN-3928], see comment in models/shared/location.js
     it.skip('state must be empty', () => {
       const testData = { state: 'MA', country: 'Canada' }
       const expectedErrors = ['state.requireEmpty.VALUE_NOT_EMPTY']

--- a/src/models/shared/name.js
+++ b/src/models/shared/name.js
@@ -24,7 +24,7 @@ const name = {
   hideMiddleName: {},
   middle: (value, attributes = {}, attributeName, options = {}) => {
     if (options.hideMiddleName || attributes.hideMiddleName || attributes.noMiddleName) {
-      return { requireEmpty: true }
+      return {}
     }
 
     if (attributes.middleInitialOnly) {

--- a/src/models/shared/name.js
+++ b/src/models/shared/name.js
@@ -25,6 +25,16 @@ const name = {
   middle: (value, attributes = {}, attributeName, options = {}) => {
     if (options.hideMiddleName || attributes.hideMiddleName || attributes.noMiddleName) {
       return {}
+
+    /**
+     * The requireEmpty constraint was added to force certain fields to have no
+     * value based on certain conditions. However, this broke some test data
+     * since currently some data structures retain dead/unused data when values
+     * are changed. For now all validation constraints are ignored for
+     * irrelevant values, but this can be added back in the future.
+     * See JIRA issue [EN-3928]
+     * */
+      // return { requireEmpty: true }
     }
 
     if (attributes.middleInitialOnly) {


### PR DESCRIPTION
## Description

Remove requireEmpty validation constraints, since often switching branches currently results in leftover data and this is introducing regressions with test scenarios.

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
