### PR TITLE
[EN-3931] Applicants only require one valid email

### DIFF
--- a/src/models/sections/__tests__/identificationContactInfo.test.js
+++ b/src/models/sections/__tests__/identificationContactInfo.test.js
@@ -34,34 +34,67 @@ describe('The identificationContactInfo section', () => {
       .toEqual(expect.arrayContaining(expectedErrors))
   })
 
-  it('does not require both email addresses', () => {
-    const testData = {
-      HomeEmail: { value: 'foobar2@local.dev' },
-      WorkEmail: {},
-      PhoneNumbers: {
-        items: [
-          {
-            Item: {
-              Telephone: {
-                noNumber: false,
-                number: '7031112222',
-                numberType: 'Home',
-                type: 'Domestic',
-                timeOfDay: 'Both',
-                extension: '',
+  describe('has atleast one valid email', () => {
+    it('does not require both email addresses', () => {
+      const testData = {
+        HomeEmail: { value: 'foobar2@local.dev' },
+        WorkEmail: {},
+        PhoneNumbers: {
+          items: [
+            {
+              Item: {
+                Telephone: {
+                  noNumber: false,
+                  number: '7031112222',
+                  numberType: 'Home',
+                  type: 'Domestic',
+                  timeOfDay: 'Both',
+                  extension: '',
+                },
               },
             },
-          },
-        ],
-      },
-    }
+          ],
+        },
+      }
 
-    const expectedErrors = [
-      'WorkEmail.presence.REQUIRED',
-    ]
+      const expectedErrors = [
+        'WorkEmail.presence.REQUIRED',
+      ]
 
-    expect(validateModel(testData, identificationContactInfo))
-      .not.toEqual(expect.arrayContaining(expectedErrors))
+      expect(validateModel(testData, identificationContactInfo))
+        .toEqual(expect.not.arrayContaining(expectedErrors))
+    })
+
+    it('does not require a value in both email addresses', () => {
+      const testData = {
+        HomeEmail: { value: 'foobar2@local.dev' },
+        WorkEmail: { value: '' },
+        PhoneNumbers: {
+          items: [
+            {
+              Item: {
+                Telephone: {
+                  noNumber: false,
+                  number: '7031112222',
+                  numberType: 'Home',
+                  type: 'Domestic',
+                  timeOfDay: 'Both',
+                  extension: '',
+                },
+              },
+            },
+          ],
+        },
+      }
+
+      const expectedErrors = [
+        'WorkEmail.model.value.presence.REQUIRED',
+        'WorkEmail.model.value.email.INVALID_EMAIL',
+      ]
+
+      expect(validateModel(testData, identificationContactInfo))
+        .toEqual(expect.not.arrayContaining(expectedErrors))
+    })
   })
 
   it('does not allow more than one of the same phone number type', () => {

--- a/src/models/sections/__tests__/identificationContactInfo.test.js
+++ b/src/models/sections/__tests__/identificationContactInfo.test.js
@@ -65,7 +65,7 @@ describe('The identificationContactInfo section', () => {
         .toEqual(expect.not.arrayContaining(expectedErrors))
     })
 
-    it('does not require a value in both email addresses', () => {
+    it('does not require a work email if has home email', () => {
       const testData = {
         HomeEmail: { value: 'foobar2@local.dev' },
         WorkEmail: { value: '' },
@@ -95,6 +95,37 @@ describe('The identificationContactInfo section', () => {
       expect(validateModel(testData, identificationContactInfo))
         .toEqual(expect.not.arrayContaining(expectedErrors))
     })
+  })
+
+  it('does not require a home email if has work email', () => {
+    const testData = {
+      HomeEmail: { value: '' },
+      WorkEmail: { value: 'foobar2@local.dev' },
+      PhoneNumbers: {
+        items: [
+          {
+            Item: {
+              Telephone: {
+                noNumber: false,
+                number: '7031112222',
+                numberType: 'Home',
+                type: 'Domestic',
+                timeOfDay: 'Both',
+                extension: '',
+              },
+            },
+          },
+        ],
+      },
+    }
+
+    const expectedErrors = [
+      'WorkEmail.model.value.presence.REQUIRED',
+      'WorkEmail.model.value.email.INVALID_EMAIL',
+    ]
+
+    expect(validateModel(testData, identificationContactInfo))
+      .toEqual(expect.not.arrayContaining(expectedErrors))
   })
 
   it('does not allow more than one of the same phone number type', () => {

--- a/src/models/sections/identificationContactInfo.js
+++ b/src/models/sections/identificationContactInfo.js
@@ -14,9 +14,12 @@ export const contactPhoneNumber = {
 const identificationContactInfo = {
   HomeEmail: (value, attributes) => {
     if (attributes.WorkEmail && attributes.WorkEmail.value) {
-      return {
-        model: { validator: email },
+      if (attributes.HomeEmail && attributes.HomeEmail.value) {
+        return {
+          model: { validator: email },
+        }
       }
+      return {}
     }
 
     return {
@@ -26,9 +29,12 @@ const identificationContactInfo = {
   },
   WorkEmail: (value, attributes) => {
     if (attributes.HomeEmail && attributes.HomeEmail.value) {
-      return {
-        model: { validator: email },
+      if (attributes.WorkEmail && attributes.WorkEmail.value) {
+        return {
+          model: { validator: email },
+        }
       }
+      return {}
     }
 
     return {


### PR DESCRIPTION
## Description
This was working in some sense previously. We only want to validate the second email if there is a valid in it. If there is no value in the email, we shouldn't validate it.

When an applicant focuses an email field, it populates with:
```
{
  name: 'HomeEmail', // can be HomeEmail or WorkEmail
  value: '',
}
```

Once they do that, it is impossible for that section to fully validate unless there is a valid email completed. This is why it is necessary to make sure there's a value before validating it.

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)