### PR TITLE
Restore USPS validation

### DIFF
--- a/api/http/validate.go
+++ b/api/http/validate.go
@@ -46,10 +46,11 @@ func (service ValidateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Extract the entity interface of the payload and validate it
+	// Perform minimal field validation on location and send it
+	// to the USPS geocoding service. Validation errors of this
+	// nature are normal, expected, and parsed by the caller.
 	if ok, err := location.Valid(); !ok {
-		service.Log.WarnError(api.PayloadInvalid, err, api.LogFields{})
-		RespondWithStructuredError(w, api.PayloadInvalid, http.StatusBadRequest)
+		EncodeErrJSON(w, err)
 		return
 	}
 

--- a/api/integration/validation_test.go
+++ b/api/integration/validation_test.go
@@ -64,7 +64,7 @@ func TestValidateHandlerInvalidAddress(t *testing.T) {
 	api.Geocode = mock.Geocoder{}
 
 	// Pass a bad address
-	location := readTestData(t, "../testdata/bad-address.json")
+	location := readTestData(t, "../testdata/nonstandardized-address.json")
 
 	w, r := standardResponseAndRequest("POST", "/me/validate", strings.NewReader(string(location)), account)
 
@@ -73,7 +73,7 @@ func TestValidateHandlerInvalidAddress(t *testing.T) {
 	}
 
 	validationHandler.ServeHTTP(w, r)
-	if status := w.Code; status != gohttp.StatusBadRequest {
+	if status := w.Code; status != gohttp.StatusOK {
 		t.Errorf("handler returned wrong status code: got %v want %v",
 			status, gohttp.StatusBadRequest)
 	}
@@ -84,8 +84,11 @@ func TestValidateHandlerInvalidAddress(t *testing.T) {
 		t.Log("Error reading the response: ", err)
 		t.Fail()
 	}
-	// Check the error message is what we expect
-	confirmErrorMsg(t, responseJSON, "Payload is invalid")
+
+	// mock geocoder does not populate geocoding JSON response
+	if len(responseJSON) != 0 {
+		t.Fail()
+	}
 }
 
 func TestValidateHandlerBadEntity(t *testing.T) {

--- a/api/testdata/nonstandardized-address.json
+++ b/api/testdata/nonstandardized-address.json
@@ -1,0 +1,11 @@
+{
+  "type": "location",
+  "props": {
+    "layout": "Address",
+    "street": "Legal",
+    "city": "Scape",
+    "state": "CA",
+    "zipcode": "",
+    "country": "United States"
+  }
+}

--- a/api/usps/usps.go
+++ b/api/usps/usps.go
@@ -69,18 +69,18 @@ func (g Geocoder) query(geoValues api.GeocodeValues) (results api.GeocodeResults
 	// Check if we've encountered an error
 	if foundAddress.Error != nil {
 		if errCode, ok := ErrorCodes[foundAddress.Error.Number]; ok {
-			g.Log.Warn(api.USPSKnownErrorCode, api.LogFields{"code": errCode})
+			g.Log.Debug(api.USPSKnownErrorCode, api.LogFields{"code": errCode})
 			return results, fmt.Errorf("%v", errCode)
 		}
 		errCode := ErrorCodes["Generic"]
-		g.Log.Warn(api.USPSUnknownErrorCode, api.LogFields{"code": errCode})
+		g.Log.Debug(api.USPSUnknownErrorCode, api.LogFields{"code": errCode})
 		return results, fmt.Errorf("%v", errCode)
 
 	}
 
 	if strings.ContainsAny(foundAddress.ReturnText, "Default Address") {
 		errCode := ErrorCodes["Default Address"]
-		g.Log.Warn(api.USPSKnownErrorCode, api.LogFields{"code": errCode})
+		g.Log.Debug(api.USPSKnownErrorCode, api.LogFields{"code": errCode})
 		return results, fmt.Errorf("%v", errCode)
 	}
 
@@ -91,7 +91,7 @@ func (g Geocoder) query(geoValues api.GeocodeValues) (results api.GeocodeResults
 	// returned by the validation response. If there is a mismatch, mark as partial
 	if results.HasPartial() {
 		errCode := ErrorCodes["Partial"]
-		g.Log.Warn(api.USPSKnownErrorCode, api.LogFields{"code": errCode})
+		g.Log.Debug(api.USPSKnownErrorCode, api.LogFields{"code": errCode})
 		return results, fmt.Errorf(errCode)
 	}
 


### PR DESCRIPTION
In https://github.com/18F/culper/pull/1815/commits/b486569bc624ace533224585b767fee020e0d8ed the API behavior for `/me/validate` was unintentionally changed, resulting in USPS geocoding errors returning a web service level error when they should return an HTTP OK and a JSON response body.

This PR reverts that and cleans up some of the logging related to USPS geocoding calls.