### PR TITLE
[EN-3922] Fix mandatory counseling or treatment DrugType validation model

### DIFF
--- a/src/models/__tests__/drugOrderedTreatment.test.js
+++ b/src/models/__tests__/drugOrderedTreatment.test.js
@@ -5,7 +5,6 @@ describe('The drugOrderedTreatment model', () => {
   it('validates required fields', () => {
     const testData = {}
     const expectedErrors = [
-      'DrugType.presence.REQUIRED',
       'Explanation.presence.REQUIRED',
       'ActionTaken.presence.REQUIRED',
       'OrderedBy.presence.REQUIRED',
@@ -15,8 +14,9 @@ describe('The drugOrderedTreatment model', () => {
       .toEqual(expect.arrayContaining(expectedErrors))
   })
 
-  it('DrugType must have a valid value', () => {
+  it('DrugType must have a valid value if ActionTaken', () => {
     const testData = {
+      ActionTaken: { value: 'Yes' },
       DrugType: { value: '' },
     }
     const expectedErrors = [

--- a/src/models/drugOrderedTreatment.js
+++ b/src/models/drugOrderedTreatment.js
@@ -4,7 +4,15 @@ import phone from 'models/shared/phone'
 // import { drugTypes } from 'constants/enums/substanceOptions'
 
 const drugOrderedTreatment = {
-  DrugType: { presence: true, hasValue: { validator: { exclusion: ['Other'] } } },
+  DrugType: (value, attributes) => {
+    if (checkValue(attributes.ActionTaken, 'Yes')) {
+      return {
+        presence: true,
+        hasValue: { validator: { exclusion: ['Other'] } },
+      }
+    }
+    return {}
+  },
   // TODO - add this back after fixing DrugType structure
   /*
   DrugType: { presence: true, hasValue: { validator: { inclusion: drugTypes } } },


### PR DESCRIPTION
## Description

The `DrugType` should only be validated if the applicant has taken action to receive counseling or treatment.

This validation model was verified against 23.21.1 in the validation matrix.

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
