### PR TITLE
Close the DB after every test

### DIFF
--- a/api/database.go
+++ b/api/database.go
@@ -35,4 +35,5 @@ type DatabaseService interface {
 	Count(model interface{}, condition string, params ...interface{}) int
 	CountExpr(model interface{}, expr string, retval interface{}, condition string, params ...interface{})
 	Array(model interface{}, expr string, retval interface{}, condition string, params ...interface{})
+	Close() error
 }

--- a/api/integration/add_empty_value_test.go
+++ b/api/integration/add_empty_value_test.go
@@ -8,6 +8,7 @@ import (
 
 func TestAddEmptyValue(t *testing.T) {
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 
 	section := readTestData(t, "../testdata/history/history-employment-no-value.json")

--- a/api/integration/application_status_test.go
+++ b/api/integration/application_status_test.go
@@ -17,6 +17,7 @@ import (
 func TestStatus(t *testing.T) {
 
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 
 	sections := []struct {
@@ -137,6 +138,7 @@ func (s errorStatusStore) LoadApplication(accountID int) (api.Application, error
 func TestStatusFetchError(t *testing.T) {
 	var mockStore errorStatusStore
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createLockedTestAccount(t, services.db)
 
 	w, req := standardResponseAndRequest("GET", "/me/status", nil, account)
@@ -172,6 +174,7 @@ func TestStatusFetchError(t *testing.T) {
 func TestLockedStatus(t *testing.T) {
 
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createLockedTestAccount(t, services.db)
 
 	w, req := standardResponseAndRequest("GET", "/me/status", nil, account)

--- a/api/integration/basic_auth_test.go
+++ b/api/integration/basic_auth_test.go
@@ -29,6 +29,7 @@ func TestBasicAuthDisabled(t *testing.T) {
 	// Basic Auth not enabled
 	os.Setenv(api.BasicEnabled, "0")
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	sessionService := session.NewSessionService(5*time.Minute, services.store, services.log)
 
 	account := createTestAccount(t, services.db)
@@ -93,6 +94,7 @@ func TestBasicNoPassword(t *testing.T) {
 	// Basic Auth enabled
 	os.Setenv(api.BasicEnabled, "1")
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	sessionService := session.NewSessionService(5*time.Minute, services.store, services.log)
 
 	account := createTestAccount(t, services.db)
@@ -156,6 +158,7 @@ func TestBasicNoUsername(t *testing.T) {
 	// Basic Auth enabled
 	os.Setenv(api.BasicEnabled, "1")
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	sessionService := session.NewSessionService(5*time.Minute, services.store, services.log)
 
 	account := createTestAccount(t, services.db)
@@ -219,6 +222,7 @@ func TestBasicAccountError(t *testing.T) {
 	// Basic Auth enabled
 	os.Setenv(api.BasicEnabled, "1")
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	sessionService := session.NewSessionService(5*time.Minute, services.store, services.log)
 
 	account := createTestAccount(t, services.db)
@@ -284,6 +288,7 @@ func TestBasicWrongPassword(t *testing.T) {
 	// Basic Auth enabled
 	os.Setenv(api.BasicEnabled, "1")
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	sessionService := session.NewSessionService(5*time.Minute, services.store, services.log)
 
 	account := createTestAccount(t, services.db)

--- a/api/integration/clear_yes_no_test.go
+++ b/api/integration/clear_yes_no_test.go
@@ -19,6 +19,7 @@ import (
 func TestClearEmptyAccount(t *testing.T) {
 	// get a setup environment.
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 
 	// Hacky, but seems OK for these tests. Technically you shouldn't be able to submit
@@ -147,6 +148,7 @@ func rejectSection(t *testing.T, services serviceSet, json []byte, sectionName s
 
 func TestClearBasicSectionNos(t *testing.T) {
 	services := cleanTestServices(t)
+	defer services.closeDB()
 
 	basicTests := []struct {
 		path       string
@@ -261,6 +263,7 @@ func TestClearBasicSectionNos(t *testing.T) {
 
 func TestClearComplexSectionNos(t *testing.T) {
 	services := cleanTestServices(t)
+	defer services.closeDB()
 
 	tests := []struct {
 		path string

--- a/api/integration/csrf_test.go
+++ b/api/integration/csrf_test.go
@@ -23,6 +23,7 @@ func giveCookie(t *testing.T, response *gohttp.Response, request *gohttp.Request
 
 func TestCSRFToken(t *testing.T) {
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 
 	statusRespW, statusReq := standardResponseAndRequest("GET", "/me/status", nil, account)
@@ -110,6 +111,7 @@ func TestCSRFToken(t *testing.T) {
 
 func TestGoodCSRFToken(t *testing.T) {
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 
 	statusRespW, statusReq := standardResponseAndRequest("GET", "/me/status", nil, account)
@@ -176,6 +178,7 @@ func TestGoodCSRFToken(t *testing.T) {
 
 func TestGarbageCSRFToken(t *testing.T) {
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 
 	statusRespW, statusReq := standardResponseAndRequest("GET", "/me/status", nil, account)
@@ -263,6 +266,7 @@ func TestGarbageCSRFToken(t *testing.T) {
 
 func TestCSRFTokenSetsAuthKey(t *testing.T) {
 	services := cleanTestServices(t)
+	defer services.closeDB()
 
 	authKey := []byte("")
 	_, csrfErr := http.NewCSRFMiddleware(services.log, authKey, true)

--- a/api/integration/delete_attachment_test.go
+++ b/api/integration/delete_attachment_test.go
@@ -26,6 +26,7 @@ func TestDeleteAttachment(t *testing.T) {
 	// Attachments enabled
 	os.Setenv(api.AttachmentsEnabled, "1")
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 
 	certificationPath := "../testdata/attachments/signature-form.pdf"
@@ -122,6 +123,7 @@ func TestDeleteAttachmentDisabled(t *testing.T) {
 	// Attachments enabled
 	os.Setenv(api.AttachmentsEnabled, "1")
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 
 	certificationPath := "../testdata/attachments/signature-form.pdf"
@@ -194,6 +196,7 @@ func TestDeleteAttachmentDisabled(t *testing.T) {
 
 func TestDeleteAttachmentLockedAccount(t *testing.T) {
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 	// Lock account
 	account.Status = api.StatusSubmitted
@@ -232,6 +235,7 @@ func TestDeleteAttachmentLockedAccount(t *testing.T) {
 func TestDeleteAttachmentError(t *testing.T) {
 	var mockStore errorDeleteAttachmentStore
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 
 	delAttachmentHandler := http.AttachmentDeleteHandler{
@@ -277,6 +281,7 @@ func TestDeleteAttachmentError(t *testing.T) {
 
 func TestDeleteAttachmentBadID(t *testing.T) {
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 
 	delAttachmentHandler := http.AttachmentDeleteHandler{

--- a/api/integration/form_version_test.go
+++ b/api/integration/form_version_test.go
@@ -12,6 +12,7 @@ import (
 func TestFormVersionReturned(t *testing.T) {
 
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 
 	w, r := standardResponseAndRequest("GET", "/me/form", nil, account)
@@ -65,6 +66,7 @@ func TestFormVersionSave(t *testing.T) {
 	// The client cannot set the form version via the API, this test confirms it's an error.
 
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 
 	fmt.Println("Account ID", account.ID)

--- a/api/integration/helpers_test.go
+++ b/api/integration/helpers_test.go
@@ -40,6 +40,15 @@ type serviceSet struct {
 	store api.StorageService
 }
 
+func (s serviceSet) closeDB() {
+	dbErr := s.db.Close()
+	storeErr := s.store.Close()
+	if dbErr != nil || storeErr != nil {
+		// Since this is always called in tests in defer, we just swallow the errors and log them.
+		fmt.Println("Got an error trying to close the db: ", dbErr, storeErr)
+	}
+}
+
 func cleanTestServices(t *testing.T) serviceSet {
 	t.Helper()
 

--- a/api/integration/http_session_test.go
+++ b/api/integration/http_session_test.go
@@ -55,6 +55,7 @@ func makeAuthenticatedFormRequest(services serviceSet, sessionService *session.S
 
 func TestFullSessionHTTPFlow_Unauthenticated(t *testing.T) {
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	sessionService := session.NewSessionService(5*time.Minute, services.store, services.log)
 
 	response := makeAuthenticatedFormRequest(services, sessionService, "")
@@ -66,6 +67,7 @@ func TestFullSessionHTTPFlow_Unauthenticated(t *testing.T) {
 
 func TestFullSessionHTTPFlow_BadAuthentication(t *testing.T) {
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	sessionService := session.NewSessionService(5*time.Minute, services.store, services.log)
 
 	response := makeAuthenticatedFormRequest(services, sessionService, "GARBAGE")
@@ -79,6 +81,7 @@ func TestFullSessionHTTPFlow_BadAuthentication(t *testing.T) {
 func TestFormIndent(t *testing.T) {
 	os.Setenv(api.IndentJSON, "1")
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 
 	w, r := standardResponseAndRequest("GET", "/me/form", nil, account)
@@ -113,6 +116,7 @@ func TestFullSessionHTTPFlow_SAMLAuthenticated(t *testing.T) {
 	os.Setenv("SAML_CONSUMER_SERVICE_URL", "")
 
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	sessionService := session.NewSessionService(5*time.Minute, services.store, services.log)
 
 	samlService := &saml.Service{
@@ -252,6 +256,7 @@ func TestFullSessionHTTPFlow_SAMLFailure(t *testing.T) {
 	os.Setenv(api.SamlEnabled, "0")
 
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	sessionService := session.NewSessionService(5*time.Minute, services.store, services.log)
 
 	samlService := &saml.Service{
@@ -307,6 +312,7 @@ func TestFullSessionHTTPFlow_SAMLFailure(t *testing.T) {
 func TestFullSessionHTTPFlow_BasicAuthenticated(t *testing.T) {
 	os.Setenv(api.BasicEnabled, "1")
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	sessionService := session.NewSessionService(5*time.Minute, services.store, services.log)
 
 	account := createTestAccount(t, services.db)

--- a/api/integration/list_attachment_test.go
+++ b/api/integration/list_attachment_test.go
@@ -28,6 +28,7 @@ func TestListAttachments(t *testing.T) {
 	// Attachments enabled
 	os.Setenv(api.AttachmentsEnabled, "1")
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 
 	listAttachmentHandler := http.AttachmentListHandler{
@@ -139,6 +140,7 @@ func TestListAttachmentDisabled(t *testing.T) {
 	// Attachments not enabled
 	os.Setenv(api.AttachmentsEnabled, "0")
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 
 	listAttachmentHandler := http.AttachmentListHandler{
@@ -173,6 +175,7 @@ func TestListAttachmentDisabled(t *testing.T) {
 func TestListAttachmentError(t *testing.T) {
 	var mockStore errorListAttachmentStore
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 
 	listAttachmentHandler := http.AttachmentListHandler{
@@ -210,6 +213,7 @@ func TestListNoAttachments(t *testing.T) {
 	// Attachments enabled
 	os.Setenv(api.AttachmentsEnabled, "1")
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 
 	listAttachmentHandler := http.AttachmentListHandler{

--- a/api/integration/reject_test.go
+++ b/api/integration/reject_test.go
@@ -16,6 +16,7 @@ import (
 func TestDeleteSignaturePDFs(t *testing.T) {
 
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 
 	xmlService := xml.NewXMLService("../templates/")

--- a/api/integration/save_attachment_test.go
+++ b/api/integration/save_attachment_test.go
@@ -44,6 +44,7 @@ func postAttachmentRequest(t *testing.T, filename string, filebytes []byte, acco
 func TestSaveAttachment(t *testing.T) {
 
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 
 	certificationPath := "../testdata/attachments/signature-form.pdf"
@@ -125,6 +126,7 @@ func TestSaveAttachmentDisabled(t *testing.T) {
 	os.Setenv(api.AttachmentsEnabled, "0")
 
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 
 	saveAttachmentHandler := http.AttachmentSaveHandler{
@@ -161,6 +163,7 @@ func TestSaveAttachmentLockedAccount(t *testing.T) {
 	// Attachments enabled
 	os.Setenv(api.AttachmentsEnabled, "1")
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 	// Lock account
 	account.Status = api.StatusSubmitted
@@ -199,6 +202,7 @@ func TestSaveAttachmentNoFile(t *testing.T) {
 	// Attachments enabled
 	os.Setenv(api.AttachmentsEnabled, "1")
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 
 	saveAttachmentHandler := http.AttachmentSaveHandler{
@@ -234,6 +238,7 @@ func TestSaveAttachmentTooBig(t *testing.T) {
 	// Set FileMaximumSize very small
 	os.Setenv(api.FileMaximumSize, "1")
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 
 	certificationPath := "../testdata/attachments/signature-form.pdf"
@@ -286,6 +291,7 @@ func TestCreateAttachmentError(t *testing.T) {
 	os.Setenv(api.AttachmentsEnabled, "1")
 	var mockStore errorCreateAttachmentStore
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 
 	certificationPath := "../testdata/attachments/signature-form.pdf"
@@ -328,6 +334,7 @@ func TestGetAttachmentsDisabled(t *testing.T) {
 	os.Setenv(api.AttachmentsEnabled, "1")
 
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 
 	certificationPath := "../testdata/attachments/signature-form.pdf"
@@ -404,6 +411,7 @@ func TestGetAttachmentBadID(t *testing.T) {
 	os.Setenv(api.AttachmentsEnabled, "1")
 
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 
 	certificationPath := "../testdata/attachments/signature-form.pdf"

--- a/api/integration/save_sections_test.go
+++ b/api/integration/save_sections_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestSaveSection(t *testing.T) {
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 
 	tests := []struct {
@@ -151,6 +152,7 @@ func TestSaveSection(t *testing.T) {
 // TestSaveMultipleSections makes sure that calls to /save are addative.
 func TestSaveMultipleSections(t *testing.T) {
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 
 	employmentSection := readTestData(t, "../testdata/history/history-employment-full.json")
@@ -227,6 +229,7 @@ func TestSaveMultipleSections(t *testing.T) {
 func TestDeleteApplication(t *testing.T) {
 
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 
 	section := readTestData(t, "../testdata/identification/identification-birthplace-full.json")

--- a/api/integration/session_test.go
+++ b/api/integration/session_test.go
@@ -11,7 +11,8 @@ import (
 
 func TestFullSessionFlow(t *testing.T) {
 	// get a store
-	services := cleanTestServices(t) // actually *returning* clean test services
+	services := cleanTestServices(t)
+	defer services.closeDB() // actually *returning* clean test services
 
 	// create a user
 	testUser := createTestAccount(t, services.db)

--- a/api/integration/submission_test.go
+++ b/api/integration/submission_test.go
@@ -88,6 +88,7 @@ func checkInfoRelease(t *testing.T, release api.Attachment) {
 
 func TestSubmitter(t *testing.T) {
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 
 	mockClock := clock.NewMock()
@@ -216,6 +217,7 @@ func TestSubmitter(t *testing.T) {
 
 func TestLockedAccountSubmitter(t *testing.T) {
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 	account.Status = api.StatusSubmitted
 

--- a/api/integration/validation_test.go
+++ b/api/integration/validation_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestCanValidateLocation(t *testing.T) {
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 	api.Geocode = mock.Geocoder{}
 
@@ -37,6 +38,7 @@ func TestCanValidateLocation(t *testing.T) {
 
 func TestCanNotValidateSomethingElse(t *testing.T) {
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 	api.Geocode = mock.Geocoder{}
 
@@ -60,6 +62,7 @@ func TestCanNotValidateSomethingElse(t *testing.T) {
 
 func TestValidateHandlerInvalidAddress(t *testing.T) {
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 	api.Geocode = mock.Geocoder{}
 
@@ -93,6 +96,7 @@ func TestValidateHandlerInvalidAddress(t *testing.T) {
 
 func TestValidateHandlerBadEntity(t *testing.T) {
 	services := cleanTestServices(t)
+	defer services.closeDB()
 	account := createTestAccount(t, services.db)
 	api.Geocode = mock.Geocoder{}
 

--- a/api/mock/database.go
+++ b/api/mock/database.go
@@ -68,3 +68,8 @@ func (service *DatabaseService) Select(query interface{}) error {
 	service.SelectCount++
 	return service.SelectFn(query)
 }
+
+// Close closes the db connection
+func (service *DatabaseService) Close() error {
+	return nil
+}

--- a/api/mock/store.go
+++ b/api/mock/store.go
@@ -74,3 +74,8 @@ func (s *StorageService) DeleteSession(sessionKey string) error {
 func (s *StorageService) ExtendAndFetchSessionAccount(sessionKey string, sessionDuration time.Duration) (api.Account, api.Session, error) {
 	return api.Account{}, api.Session{}, nil
 }
+
+// Close closes the db connection
+func (s *StorageService) Close() error {
+	return nil
+}

--- a/api/postgresql/db.go
+++ b/api/postgresql/db.go
@@ -198,3 +198,8 @@ func explicitNotFoundError(err error) error {
 	}
 	return err
 }
+
+// Close closes the DB connection
+func (service *Service) Close() error {
+	return service.database.Close()
+}

--- a/api/postgresql/db_test.go
+++ b/api/postgresql/db_test.go
@@ -24,6 +24,7 @@ func TestAccountPersistence(t *testing.T) {
 	}
 
 	service := NewPostgresService(dbConf, logger)
+	defer service.Close()
 
 	api.Geocode = mock.Geocoder{}
 

--- a/api/session/session_test.go
+++ b/api/session/session_test.go
@@ -46,6 +46,7 @@ func TestAuthExists(t *testing.T) {
 
 	timeout := 5 * time.Second
 	store := getSimpleStore()
+	defer store.Close()
 	sessionLog := &mock.LogService{}
 	session := NewSessionService(timeout, store, sessionLog)
 
@@ -56,6 +57,7 @@ func TestLogSessionCreatedDestroyed(t *testing.T) {
 
 	timeout := 5 * time.Second
 	store := getSimpleStore()
+	defer store.Close()
 	sessionLog := &logRecorder{}
 
 	session := NewSessionService(timeout, store, sessionLog)
@@ -129,6 +131,7 @@ func TestLogSessionExpired(t *testing.T) {
 
 	timeout := -5 * time.Second
 	store := getSimpleStore()
+	defer store.Close()
 	sessionLog := &logRecorder{}
 
 	session := NewSessionService(timeout, store, sessionLog)
@@ -177,6 +180,7 @@ func TestLogConcurrentSession(t *testing.T) {
 
 	timeout := 5 * time.Second
 	store := getSimpleStore()
+	defer store.Close()
 	sessionLog := &logRecorder{}
 
 	session := NewSessionService(timeout, store, sessionLog)

--- a/api/simplestore/applications_test.go
+++ b/api/simplestore/applications_test.go
@@ -11,6 +11,7 @@ import (
 func TestSaveSection(t *testing.T) {
 
 	store := getSimpleStore()
+	defer store.Close()
 	account := CreateTestAccount(t, store)
 
 	sectionFilename := "../testdata/identification/identification-name.json"
@@ -91,6 +92,7 @@ func TestSaveSection(t *testing.T) {
 func TestStoreErrors(t *testing.T) {
 
 	store := getSimpleStore()
+	defer store.Close()
 	account := CreateTestAccount(t, store)
 
 	sectionFilename := "../testdata/identification/identification-name.json"

--- a/api/simplestore/attachments_test.go
+++ b/api/simplestore/attachments_test.go
@@ -11,6 +11,7 @@ import (
 func TestSingleAttachment(t *testing.T) {
 
 	store := getSimpleStore()
+	defer store.Close()
 	account := CreateTestAccount(t, store)
 
 	certificationPath := "../testdata/attachments/signature-form.pdf"
@@ -86,6 +87,7 @@ func TestSingleAttachment(t *testing.T) {
 func TestListAttachments(t *testing.T) {
 
 	store := getSimpleStore()
+	defer store.Close()
 	account := CreateTestAccount(t, store)
 
 	testAttachments := []string{

--- a/api/simplestore/sessions_test.go
+++ b/api/simplestore/sessions_test.go
@@ -180,6 +180,7 @@ func TestDeleteSessionRemovesRecord(t *testing.T) {
 
 func TestDeleteSessionReturnsErrIfSessionNotFound(t *testing.T) {
 	store := getSimpleStore()
+	defer store.Close()
 	sessionKeyWithNoAssociatedRecord := uuid.New().String()
 
 	err := store.DeleteSession(sessionKeyWithNoAssociatedRecord)

--- a/api/simplestore/simple_store.go
+++ b/api/simplestore/simple_store.go
@@ -41,3 +41,8 @@ func NewSimpleStore(connectionString string, logger api.LogService, serializer a
 
 	return store, nil
 }
+
+// Close closes the db connection
+func (s SimpleStore) Close() error {
+	return s.db.Close()
+}

--- a/api/store.go
+++ b/api/store.go
@@ -51,4 +51,7 @@ type StorageService interface {
 	DeleteSession(sessionKey string) error
 	// ExtendAndFetchSessionAccount fetches an account and session data from the db
 	ExtendAndFetchSessionAccount(sessionKey string, expirationDuration time.Duration) (Account, Session, error)
+
+	// Close closes the db connection
+	Close() error
 }


### PR DESCRIPTION
## Description

We've seen issues running `make test-go` where the db refuses to connect because there are too many connections. I was unable to reproduce that reliably, but we have not been closing out our db connections after every test. This PR adds a deferred db.Close() to every test that uses the db. 

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects

More details about this can be found in [docs/review.md](docs/review.md)