### PR TITLE
EN-3906 allow 4-20 digits in international number

### DIFF
--- a/src/components/Form/Telephone/Telephone.jsx
+++ b/src/components/Form/Telephone/Telephone.jsx
@@ -15,7 +15,6 @@ const defaultNumbers = {
   },
   international: {
     first: '',
-    second: '',
   },
 }
 
@@ -50,8 +49,7 @@ export default class Telephone extends ValidationElement {
         third: this.parseNumber(6, 10, props.number),
       },
       international: {
-        first: this.parseNumber(0, 3, props.number),
-        second: this.parseNumber(3, 13, props.number),
+        first: this.parseNumber(props.number),
       },
     }
 
@@ -123,7 +121,6 @@ export default class Telephone extends ValidationElement {
   updateInternationalNumber = (values) => {
     const fieldNameMap = {
       int_first: 'first',
-      int_second: 'second',
     }
 
     this.setState(prevState => ({
@@ -179,8 +176,7 @@ export default class Telephone extends ValidationElement {
           .trim()
       case 'International':
         return [
-          padleft(this.state.international.first, 3),
-          this.state.international.second,
+          this.state.international.first,
         ]
           .join('')
           .trim()
@@ -211,10 +207,6 @@ export default class Telephone extends ValidationElement {
 
   handleErrorInternationalFirst = (value, arr) => (
     this.handleErrorInternational('first', value, arr)
-  )
-
-  handleErrorInternationalSecond = (value, arr) => (
-    this.handleErrorInternational('second', value, arr)
   )
 
   handleErrorInternationalExtension = (value, arr) => (
@@ -445,41 +437,18 @@ export default class Telephone extends ValidationElement {
           <Text
             name="int_first"
             ref="int_first"
-            className="number three"
+            className="number ten"
             label=""
-            ariaLabel={i18n.t('telephone.aria.countryCode')}
+            ariaLabel={i18n.t('telephone.aria.phoneNumber')}
             disabled={this.props.noNumber}
-            maxlength="3"
-            pattern="\d{1,3}"
+            maxlength="20"
+            pattern="\d{4,20}"
             prefilter={digitsOnly}
             readonly={this.props.readonly}
             required={this.required('International')}
             value={trimleading(this.state.international.first)}
             onUpdate={this.updateInternationalNumber}
             onError={this.handleErrorInternationalFirst}
-            tabNext={() => {
-              this.props.tab(this.refs.int_second.refs.text.refs.input)
-            }}
-          />
-          <span className="separator">-</span>
-          <Text
-            name="int_second"
-            ref="int_second"
-            className="number ten"
-            label=""
-            ariaLabel={i18n.t('telephone.aria.phoneNumber')}
-            disabled={this.props.noNumber}
-            maxlength="10"
-            pattern="\d{10}"
-            prefilter={digitsOnly}
-            readonly={this.props.readonly}
-            required={this.required('International')}
-            value={trimleading(this.state.international.second)}
-            onUpdate={this.updateInternationalNumber}
-            onError={this.handleErrorInternationalSecond}
-            tabBack={() => {
-              this.props.tab(this.refs.int_first.refs.text.refs.input)
-            }}
             tabNext={() => {
               this.props.tab(this.refs.int_extension.refs.text.refs.input)
             }}
@@ -503,7 +472,7 @@ export default class Telephone extends ValidationElement {
             onUpdate={this.updateExtension}
             onError={this.handleErrorInternationalExtension}
             tabBack={() => {
-              this.props.tab(this.refs.int_second.refs.text.refs.input)
+              this.props.tab(this.refs.int_first.refs.text.refs.input)
             }}
           />
         </div>
@@ -715,7 +684,7 @@ Telephone.errors = [
               && !!props.domestic.third
             )
           case 'International':
-            return !!props.international.first && !!props.international.second
+            return !!props.international.first
           default:
             return false
         }

--- a/src/components/Form/Telephone/Telephone.jsx
+++ b/src/components/Form/Telephone/Telephone.jsx
@@ -41,6 +41,7 @@ const digitsOnly = (value = '') => {
 export default class Telephone extends ValidationElement {
   constructor(props) {
     super(props)
+
     this.state = {
       uid: `${this.props.name}-${super.guid()}`,
       domestic: {
@@ -49,10 +50,9 @@ export default class Telephone extends ValidationElement {
         third: this.parseNumber(6, 10, props.number),
       },
       international: {
-        first: this.parseNumber(props.number),
+        first: props.number,
       },
     }
-
     this.domestic = this.domestic.bind(this)
     this.international = this.international.bind(this)
     this.errors = []
@@ -175,11 +175,7 @@ export default class Telephone extends ValidationElement {
           .join('')
           .trim()
       case 'International':
-        return [
-          this.state.international.first,
-        ]
-          .join('')
-          .trim()
+        return this.state.international.first.trim()
       default:
         return ''
     }
@@ -597,7 +593,7 @@ export default class Telephone extends ValidationElement {
           <div
             className={`phonetype ${
               this.props.noNumber ? 'disabled' : ''
-            }`.trim()}
+              }`.trim()}
           >
             <label>{i18n.t('telephone.numberType.title')}</label>
             <RadioGroup
@@ -659,7 +655,7 @@ Telephone.defaultProps = {
   tab: (input) => {
     input.focus()
   },
-  onUpdate: () => {},
+  onUpdate: () => { },
   onError: (value, arr) => arr,
 }
 

--- a/src/components/Form/Telephone/Telephone.scss
+++ b/src/components/Form/Telephone/Telephone.scss
@@ -33,7 +33,7 @@
     }
 
     &.ten {
-      width: 14rem;
+      width: 30rem;
     }
 
     label {

--- a/src/components/Form/Telephone/Telephone.test.jsx
+++ b/src/components/Form/Telephone/Telephone.test.jsx
@@ -137,9 +137,6 @@ describe('The Telephone component', () => {
       .find({ type: 'text', name: 'int_first' })
       .simulate('change', { target: { value: '111' } })
     component
-      .find({ type: 'text', name: 'int_second' })
-      .simulate('change', { target: { value: '222' } })
-    component
       .find({ type: 'text', name: 'int_extension' })
       .simulate('change', { target: { value: '4444' } })
     component.find('.nonumber input').simulate('change')
@@ -189,7 +186,7 @@ describe('The Telephone component', () => {
 
     tabbed = false
     componentInternational
-      .find({ type: 'text', name: 'int_second' })
+      .find({ type: 'text', name: 'int_extension' })
       .simulate('keydown', { keyCode: 48, target: { value: '1234567890' } })
     expect(tabbed).toBe(true)
   })
@@ -235,7 +232,7 @@ describe('The Telephone component', () => {
 
     tabbed = false
     componentInternational
-      .find({ type: 'text', name: 'int_second' })
+      .find({ type: 'text', name: 'int_first' })
       .simulate('keydown', { keyCode: 8, target: { value: '' } })
     expect(tabbed).toBe(true)
   })

--- a/src/components/Form/Telephone/Telephone.test.jsx
+++ b/src/components/Form/Telephone/Telephone.test.jsx
@@ -7,7 +7,6 @@ describe('The Telephone component', () => {
     const component = mount(<Telephone name="phone" type="International" />)
     expect(component.find('.domestic-number').length).toEqual(1)
     expect(component.find('input[name="int_first"]').length).toEqual(1)
-    expect(component.find('input[name="int_second"]').length).toEqual(1)
   })
 
   it('populates domestic fields using number', () => {
@@ -142,7 +141,7 @@ describe('The Telephone component', () => {
     component.find('.nonumber input').simulate('change')
     component.find('.time.day input').simulate('change')
     component.find('.phonetype-option.work input').simulate('change')
-    expect(updated).toBe(6)
+    expect(updated).toBe(5)
   })
 
   it('can autotab forward', () => {
@@ -181,13 +180,7 @@ describe('The Telephone component', () => {
     tabbed = false
     componentInternational
       .find({ type: 'text', name: 'int_first' })
-      .simulate('keydown', { keyCode: 48, target: { value: '123' } })
-    expect(tabbed).toBe(true)
-
-    tabbed = false
-    componentInternational
-      .find({ type: 'text', name: 'int_extension' })
-      .simulate('keydown', { keyCode: 48, target: { value: '1234567890' } })
+      .simulate('keydown', { keyCode: 48, target: { value: '12345678901234567890' } })
     expect(tabbed).toBe(true)
   })
 
@@ -227,12 +220,6 @@ describe('The Telephone component', () => {
     tabbed = false
     componentInternational
       .find({ type: 'text', name: 'int_extension' })
-      .simulate('keydown', { keyCode: 8, target: { value: '' } })
-    expect(tabbed).toBe(true)
-
-    tabbed = false
-    componentInternational
-      .find({ type: 'text', name: 'int_first' })
       .simulate('keydown', { keyCode: 8, target: { value: '' } })
     expect(tabbed).toBe(true)
   })

--- a/src/components/Section/Identification/ContactInformation/ContactInformation.test.jsx
+++ b/src/components/Section/Identification/ContactInformation/ContactInformation.test.jsx
@@ -81,13 +81,13 @@ describe('The ContactInformation component', () => {
         .find('.summary strong')
         .at(2)
         .text()
-    ).toEqual('+001 1234567890 x1234')
+    ).toEqual('+0011234567890 x1234')
     expect(
       component
         .find('.summary strong')
         .at(3)
         .text()
-    ).toEqual('+001 1234567890')
+    ).toEqual('+0011234567890')
   })
 
   it('should filter empty items out leaving only the minimum visible', () => {
@@ -115,7 +115,7 @@ describe('The ContactInformation component', () => {
         .find('.summary strong')
         .at(0)
         .text()
-    ).toEqual('+001 1234567890')
+    ).toEqual('+0011234567890')
   })
 
   it('errors when two duplicate phone numbers are displayed', () => {

--- a/src/components/Summary/TelephoneSummary.js
+++ b/src/components/Summary/TelephoneSummary.js
@@ -11,7 +11,7 @@ export const TelephoneSummary = (props, unknown = '') => {
 
     switch (props.type) {
       case 'International':
-        number = `+${number.slice(0, 3).trim()} ${number.slice(3, 13).trim()}`
+        number = `+${number.trim()}`
         if (props.extension) {
           number += ` x${props.extension}`
         }

--- a/src/components/Summary/TelephoneSummary.test.js
+++ b/src/components/Summary/TelephoneSummary.test.js
@@ -16,7 +16,7 @@ describe('The telephone summary', () => {
     }
     const summary = TelephoneSummary(phone, 'Unknown')
     expect(summary).toEqual(
-      <span className="title-case">+001 1234567890 x1234</span>
+      <span className="title-case">+0011234567890 x1234</span>
     )
   })
 

--- a/src/config/locales/en/error.js
+++ b/src/config/locales/en/error.js
@@ -767,6 +767,11 @@ export const error = {
           message: 'City name should be between 2 and 100 characters.',
           note: '',
         },
+        required: {
+          title: 'There is a problem with the City',
+          message: 'City is required if County is not filled in',
+          note: '',
+        }
       },
       state: {
         notfound: {
@@ -785,6 +790,11 @@ export const error = {
           message: 'County name must be between 2 and 100 characters',
           note: '',
         },
+        required: {
+          title: 'There is a problem with the County',
+          message: 'County is required if City is not filled in',
+          note: '',
+        }
       },
       zipcode: {
         pattern: {
@@ -1045,33 +1055,15 @@ export const error = {
     international: {
       first: {
         pattern: {
-          title: 'There is a problem with this country code',
-          message:
-            'The country code of the international number should be 3 digits between 0 and 9.',
-          note: '',
-        },
-        length: {
-          title: 'There is a problem with this country code',
-          message:
-            'The country code of the international number should be 3 digits between 0 and 9.',
-          note: '',
-        },
-        required: {
-          title: 'Your response is required',
-          message: '',
-        },
-      },
-      second: {
-        pattern: {
           title: 'There is a problem with this number',
           message:
-            'The international number should be 10 digits between 0 and 9.',
+            'The international number should be 4-20 digits between 0 and 9.',
           note: '',
         },
         length: {
           title: 'There is a problem with this number',
           message:
-            'The international number should be 10 digits between 0 and 9.',
+            'The international number should be 4-20 digits between 0 and 9.',
           note: '',
         },
         required: {

--- a/src/models/shared/__tests__/phone.test.js
+++ b/src/models/shared/__tests__/phone.test.js
@@ -101,10 +101,22 @@ describe('The phone model', () => {
   })
 
   describe('for International numbers', () => {
-    it('number must be more than 10 digits', () => {
+    it('number must be more than 3 digits', () => {
       const testData = {
         type: 'International',
-        number: '1234567890',
+        number: '123',
+      }
+
+      const expectedErrors = ['number.format.INVALID_FORMAT']
+
+      expect(validateModel(testData, phone))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('number must be less than 21 digits', () => {
+      const testData = {
+        type: 'International',
+        number: '123456789012345678901',
       }
 
       const expectedErrors = ['number.format.INVALID_FORMAT']

--- a/src/models/shared/phone.js
+++ b/src/models/shared/phone.js
@@ -43,7 +43,7 @@ const phone = {
       case 'International':
         return {
           presence: true,
-          format: { pattern: /^\d{11,}$/ },
+          format: { pattern: /^\d{4,20}$/ },
         }
       default: {
         return { presence: true }


### PR DESCRIPTION
## Description

EN-3906 System is enforcing a 10 digit minimum for international telephone numbers
Updated international phone number text boxes to allow 4-20 digits, combined country code and number boxes into one box

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
