### PR TITLE
[EN-2383] Prohibit applicants over age of 100

### DIFF
--- a/src/components/ErrorList/ErrorList.scss
+++ b/src/components/ErrorList/ErrorList.scss
@@ -59,4 +59,8 @@
       display: inline-block;
     }
   }
+
+  &.usa-alert-warning {
+    background-size: 3rem;
+  }
 }

--- a/src/components/ErrorMessage/index.jsx
+++ b/src/components/ErrorMessage/index.jsx
@@ -1,11 +1,18 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import classnames from 'classnames'
 
 const ErrorMessage = ({
-  id, title, message, note,
+  id, title, message, note, isWarning,
 }) => (
   <div
-    className="error-message error usa-alert usa-alert-error"
+    className={classnames(
+      'error-message',
+      'error',
+      'usa-alert',
+      { 'usa-alert-error': !isWarning },
+      { 'usa-alert-warning': isWarning },
+    )}
     role="alert"
     aria-live="polite"
   >
@@ -30,6 +37,7 @@ ErrorMessage.propTypes = {
   title: PropTypes.string,
   message: PropTypes.string,
   note: PropTypes.string,
+  isWarning: PropTypes.bool,
 }
 
 ErrorMessage.defaultProps = {
@@ -37,6 +45,7 @@ ErrorMessage.defaultProps = {
   title: '',
   message: '',
   note: '',
+  isWarning: false,
 }
 
 export default ErrorMessage

--- a/src/components/ErrorMessage/index.test.jsx
+++ b/src/components/ErrorMessage/index.test.jsx
@@ -37,4 +37,13 @@ describe('The error message component', () => {
     expect(component.find(select('note')).text())
       .toEqual(fixture)
   })
+
+  it('can be a warning', () => {
+    const component = shallow(
+      <ErrorMessage isWarning={true} />
+    )
+
+    expect(component.find('.usa-alert-error').length).toEqual(0)
+    expect(component.find('.usa-alert-warning').length).toEqual(1)
+  })
 })

--- a/src/components/ErrorMessageList/index.jsx
+++ b/src/components/ErrorMessageList/index.jsx
@@ -7,7 +7,7 @@ import ErrorMessage from 'components/ErrorMessage'
  *
  * @param {Array} errors An array of errors
  */
-const ErrorMessageList = ({ errors }) => (
+const ErrorMessageList = ({ errors, isWarning }) => (
   <div>
     {errors.map(error => (
       <ErrorMessage
@@ -16,6 +16,7 @@ const ErrorMessageList = ({ errors }) => (
         title={error.title}
         message={error.message}
         note={error.note}
+        isWarning={isWarning}
       />
     ))}
   </div>
@@ -23,10 +24,12 @@ const ErrorMessageList = ({ errors }) => (
 
 ErrorMessageList.propTypes = {
   errors: PropTypes.arrayOf(PropTypes.object),
+  isWarning: PropTypes.bool,
 }
 
 ErrorMessageList.defaultProps = {
   errors: [],
+  isWarning: false,
 }
 
 export default ErrorMessageList

--- a/src/components/Form/Location/Layouts.js
+++ b/src/components/Form/Location/Layouts.js
@@ -1,6 +1,7 @@
 export default {
   ADDRESS: 'Address',
   BIRTHPLACE: 'Birthplace',
+  IDENTIFICATION_BIRTH_PLACE: 'Identification Birthplace',
   BIRTHPLACE_WITHOUT_COUNTY: 'Birthplace without County',
   COUNTRY: 'Country',
   US_CITY_STATE_INTERNATIONAL_CITY: 'US City, State, International city',

--- a/src/components/Form/Location/Location.jsx
+++ b/src/components/Form/Location/Location.jsx
@@ -685,6 +685,18 @@ export default class Location extends ValidationElement {
    */
   fieldMappings() {
     switch (this.props.layout) {
+      case Location.IDENTIFICATION_BIRTH_PLACE:
+        return (
+          <ToggleableLocation
+            {...this.props}
+            domesticFields={['city', 'state', 'county']}
+            internationalFields={['city', 'country']}
+            onBlur={this.handleBlur}
+            onUpdate={this.updateToggleableLocation}
+            onError={this.handleError}
+            required={this.props.required}
+          />
+        )
       case Location.BIRTHPLACE:
         return (
           <ToggleableLocation
@@ -828,6 +840,7 @@ export default class Location extends ValidationElement {
 
 // Define all possible layouts for location fields
 Location.BIRTHPLACE = Layouts.BIRTHPLACE
+Location.IDENTIFICATION_BIRTH_PLACE = Layouts.IDENTIFICATION_BIRTH_PLACE
 Location.COUNTRY = Layouts.COUNTRY
 Location.US_CITY_STATE_INTERNATIONAL_CITY_COUNTRY = Layouts.US_CITY_STATE_INTERNATIONAL_CITY_COUNTRY
 Location.BIRTHPLACE_WITHOUT_COUNTY = Layouts.BIRTHPLACE_WITHOUT_COUNTY
@@ -862,8 +875,8 @@ Location.defaultProps = {
   addressBook: '',
   isPoBoxAllowed: true,
   showPostOffice: false,
-  onUpdate: () => {},
-  dispatch: () => {},
+  onUpdate: () => { },
+  dispatch: () => { },
   onError: (value, arr) => arr,
 }
 

--- a/src/components/Form/Location/ToggleableLocation.jsx
+++ b/src/components/Form/Location/ToggleableLocation.jsx
@@ -167,7 +167,8 @@ export default class ToggleableLocation extends ValidationElement {
               onError={this.onError}
               onFocus={this.props.onFocus}
               onBlur={this.props.onBlur}
-              required={this.props.required}
+              required={this.props.layout === Layouts.IDENTIFICATION_BIRTH_PLACE ? this.props.required && !this.props.county : this.props.required}
+              requireCity={this.props.layout === Layouts.IDENTIFICATION_BIRTH_PLACE ? this.props.required && !this.props.county : this.props.required}
             />
           )
         case 'county':
@@ -184,7 +185,8 @@ export default class ToggleableLocation extends ValidationElement {
               onError={this.onError}
               onBlur={this.props.onBlur}
               onFocus={this.props.onFocus}
-              required={this.props.required}
+              required={this.props.layout === Layouts.IDENTIFICATION_BIRTH_PLACE ? this.props.required && !this.props.city : this.props.required}
+              requireCounty={this.props.layout === Layouts.IDENTIFICATION_BIRTH_PLACE ? this.props.required && !this.props.city : this.props.required}
             />
           )
         case 'state':
@@ -381,14 +383,14 @@ ToggleableLocation.errors = [
       if (!props.required) {
         return true
       }
-
+      
       // Organizing the validation tests in a structure
       const branchValidations = {
         Yes: {
           fields: props => props.domesticFields,
-          city: props => !!props.city,
+          city: props => props.layout === Layouts.IDENTIFICATION_BIRTH_PLACE ? !!props.city || !!props.county : !!props.city,
           state: props => !!props.state,
-          county: props => !!props.county,
+          county: props => props.layout === Layouts.IDENTIFICATION_BIRTH_PLACE ? !!props.city || !!props.county : !!props.county,
           stateZipcode: props => !!props.state && !!props.zipcode,
           country: props => !!countryString(props.country)
         },

--- a/src/components/Form/Location/ToggleableLocation.test.jsx
+++ b/src/components/Form/Location/ToggleableLocation.test.jsx
@@ -71,4 +71,20 @@ describe('The ToggleableLocation component', () => {
     const component = mount(<ToggleableLocation {...props} />)
     expect(component.find('.usa-input-error').length).toBe(2)
   })
+
+  it ('Render if layout is BirthPlace and US', () => {
+    const props = {
+      required: true,
+      country: { value: 'United States' },
+      domesticFields: [
+        'city',
+        'county',
+        'state',
+        'country',
+        'what',
+      ]
+    }
+    const component = mount(<ToggleableLocation {...props} />)
+    expect(component.find('.usa-input-error').length).toBe(3)
+  })
 })

--- a/src/components/Form/Telephone/Telephone.jsx
+++ b/src/components/Form/Telephone/Telephone.jsx
@@ -15,7 +15,6 @@ const defaultNumbers = {
   },
   international: {
     first: '',
-    second: '',
   },
 }
 
@@ -42,6 +41,7 @@ const digitsOnly = (value = '') => {
 export default class Telephone extends ValidationElement {
   constructor(props) {
     super(props)
+
     this.state = {
       uid: `${this.props.name}-${super.guid()}`,
       domestic: {
@@ -50,11 +50,9 @@ export default class Telephone extends ValidationElement {
         third: this.parseNumber(6, 10, props.number),
       },
       international: {
-        first: this.parseNumber(0, 3, props.number),
-        second: this.parseNumber(3, 13, props.number),
+        first: props.number,
       },
     }
-
     this.domestic = this.domestic.bind(this)
     this.international = this.international.bind(this)
     this.errors = []
@@ -123,7 +121,6 @@ export default class Telephone extends ValidationElement {
   updateInternationalNumber = (values) => {
     const fieldNameMap = {
       int_first: 'first',
-      int_second: 'second',
     }
 
     this.setState(prevState => ({
@@ -178,12 +175,7 @@ export default class Telephone extends ValidationElement {
           .join('')
           .trim()
       case 'International':
-        return [
-          padleft(this.state.international.first, 3),
-          this.state.international.second,
-        ]
-          .join('')
-          .trim()
+        return this.state.international.first.trim()
       default:
         return ''
     }
@@ -211,10 +203,6 @@ export default class Telephone extends ValidationElement {
 
   handleErrorInternationalFirst = (value, arr) => (
     this.handleErrorInternational('first', value, arr)
-  )
-
-  handleErrorInternationalSecond = (value, arr) => (
-    this.handleErrorInternational('second', value, arr)
   )
 
   handleErrorInternationalExtension = (value, arr) => (
@@ -445,41 +433,18 @@ export default class Telephone extends ValidationElement {
           <Text
             name="int_first"
             ref="int_first"
-            className="number three"
+            className="number ten"
             label=""
-            ariaLabel={i18n.t('telephone.aria.countryCode')}
+            ariaLabel={i18n.t('telephone.aria.phoneNumber')}
             disabled={this.props.noNumber}
-            maxlength="3"
-            pattern="\d{1,3}"
+            maxlength="20"
+            pattern="\d{4,20}"
             prefilter={digitsOnly}
             readonly={this.props.readonly}
             required={this.required('International')}
             value={trimleading(this.state.international.first)}
             onUpdate={this.updateInternationalNumber}
             onError={this.handleErrorInternationalFirst}
-            tabNext={() => {
-              this.props.tab(this.refs.int_second.refs.text.refs.input)
-            }}
-          />
-          <span className="separator">-</span>
-          <Text
-            name="int_second"
-            ref="int_second"
-            className="number ten"
-            label=""
-            ariaLabel={i18n.t('telephone.aria.phoneNumber')}
-            disabled={this.props.noNumber}
-            maxlength="10"
-            pattern="\d{10}"
-            prefilter={digitsOnly}
-            readonly={this.props.readonly}
-            required={this.required('International')}
-            value={trimleading(this.state.international.second)}
-            onUpdate={this.updateInternationalNumber}
-            onError={this.handleErrorInternationalSecond}
-            tabBack={() => {
-              this.props.tab(this.refs.int_first.refs.text.refs.input)
-            }}
             tabNext={() => {
               this.props.tab(this.refs.int_extension.refs.text.refs.input)
             }}
@@ -503,7 +468,7 @@ export default class Telephone extends ValidationElement {
             onUpdate={this.updateExtension}
             onError={this.handleErrorInternationalExtension}
             tabBack={() => {
-              this.props.tab(this.refs.int_second.refs.text.refs.input)
+              this.props.tab(this.refs.int_first.refs.text.refs.input)
             }}
           />
         </div>
@@ -628,7 +593,7 @@ export default class Telephone extends ValidationElement {
           <div
             className={`phonetype ${
               this.props.noNumber ? 'disabled' : ''
-            }`.trim()}
+              }`.trim()}
           >
             <label>{i18n.t('telephone.numberType.title')}</label>
             <RadioGroup
@@ -690,7 +655,7 @@ Telephone.defaultProps = {
   tab: (input) => {
     input.focus()
   },
-  onUpdate: () => {},
+  onUpdate: () => { },
   onError: (value, arr) => arr,
 }
 
@@ -715,7 +680,7 @@ Telephone.errors = [
               && !!props.domestic.third
             )
           case 'International':
-            return !!props.international.first && !!props.international.second
+            return !!props.international.first
           default:
             return false
         }

--- a/src/components/Form/Telephone/Telephone.scss
+++ b/src/components/Form/Telephone/Telephone.scss
@@ -33,7 +33,7 @@
     }
 
     &.ten {
-      width: 14rem;
+      width: 30rem;
     }
 
     label {

--- a/src/components/Form/Telephone/Telephone.test.jsx
+++ b/src/components/Form/Telephone/Telephone.test.jsx
@@ -7,7 +7,6 @@ describe('The Telephone component', () => {
     const component = mount(<Telephone name="phone" type="International" />)
     expect(component.find('.domestic-number').length).toEqual(1)
     expect(component.find('input[name="int_first"]').length).toEqual(1)
-    expect(component.find('input[name="int_second"]').length).toEqual(1)
   })
 
   it('populates domestic fields using number', () => {
@@ -137,15 +136,12 @@ describe('The Telephone component', () => {
       .find({ type: 'text', name: 'int_first' })
       .simulate('change', { target: { value: '111' } })
     component
-      .find({ type: 'text', name: 'int_second' })
-      .simulate('change', { target: { value: '222' } })
-    component
       .find({ type: 'text', name: 'int_extension' })
       .simulate('change', { target: { value: '4444' } })
     component.find('.nonumber input').simulate('change')
     component.find('.time.day input').simulate('change')
     component.find('.phonetype-option.work input').simulate('change')
-    expect(updated).toBe(6)
+    expect(updated).toBe(5)
   })
 
   it('can autotab forward', () => {
@@ -184,13 +180,7 @@ describe('The Telephone component', () => {
     tabbed = false
     componentInternational
       .find({ type: 'text', name: 'int_first' })
-      .simulate('keydown', { keyCode: 48, target: { value: '123' } })
-    expect(tabbed).toBe(true)
-
-    tabbed = false
-    componentInternational
-      .find({ type: 'text', name: 'int_second' })
-      .simulate('keydown', { keyCode: 48, target: { value: '1234567890' } })
+      .simulate('keydown', { keyCode: 48, target: { value: '12345678901234567890' } })
     expect(tabbed).toBe(true)
   })
 
@@ -230,12 +220,6 @@ describe('The Telephone component', () => {
     tabbed = false
     componentInternational
       .find({ type: 'text', name: 'int_extension' })
-      .simulate('keydown', { keyCode: 8, target: { value: '' } })
-    expect(tabbed).toBe(true)
-
-    tabbed = false
-    componentInternational
-      .find({ type: 'text', name: 'int_second' })
       .simulate('keydown', { keyCode: 8, target: { value: '' } })
     expect(tabbed).toBe(true)
   })

--- a/src/components/Section/Citizenship/UsPassport/index.jsx
+++ b/src/components/Section/Citizenship/UsPassport/index.jsx
@@ -88,7 +88,7 @@ export class UsPassport extends Subsection {
       Name: values.value === 'Yes' ? this.props.Name : {},
       Number: values.value === 'Yes' ? this.props.Number : '',
       Issued: values.value === 'Yes' ? this.props.Issued : {},
-      Expired: values.value === 'Yes' ? this.props.Expired : {},
+      Expiration: values.value === 'Yes' ? this.props.Expiration : {},
     })
   }
 

--- a/src/components/Section/Identification/ApplicantBirthPlace/ApplicantBirthPlace.jsx
+++ b/src/components/Section/Identification/ApplicantBirthPlace/ApplicantBirthPlace.jsx
@@ -67,7 +67,7 @@ export class ApplicantBirthPlace extends Subsection {
           <Location
             name="birthplace"
             {...this.props.Location}
-            layout={Location.BIRTHPLACE}
+            layout={Location.IDENTIFICATION_BIRTH_PLACE}
             stateLabel={i18n.t('identification.birthplace.label.state')}
             cityLabel={i18n.t('identification.birthplace.label.city')}
             countyLabel={i18n.t('identification.birthplace.label.county')}

--- a/src/components/Section/Identification/ContactInformation/ContactInformation.test.jsx
+++ b/src/components/Section/Identification/ContactInformation/ContactInformation.test.jsx
@@ -81,13 +81,13 @@ describe('The ContactInformation component', () => {
         .find('.summary strong')
         .at(2)
         .text()
-    ).toEqual('+001 1234567890 x1234')
+    ).toEqual('+0011234567890 x1234')
     expect(
       component
         .find('.summary strong')
         .at(3)
         .text()
-    ).toEqual('+001 1234567890')
+    ).toEqual('+0011234567890')
   })
 
   it('should filter empty items out leaving only the minimum visible', () => {
@@ -115,7 +115,7 @@ describe('The ContactInformation component', () => {
         .find('.summary strong')
         .at(0)
         .text()
-    ).toEqual('+001 1234567890')
+    ).toEqual('+0011234567890')
   })
 
   it('errors when two duplicate phone numbers are displayed', () => {

--- a/src/components/Section/Legal/Investigations/HistoryItem.jsx
+++ b/src/components/Section/Legal/Investigations/HistoryItem.jsx
@@ -8,6 +8,7 @@ import {
   NotApplicable,
   DateControl,
   Text,
+  Branch,
 } from 'components/Form'
 
 import InvestigatingAgency from './InvestigatingAgency'
@@ -28,6 +29,7 @@ export default class HistoryItem extends ValidationElement {
       GrantedComments: this.props.GrantedComments,
       ClearanceLevelNotApplicable: this.props.ClearanceLevelNotApplicable,
       ClearanceLevel: this.props.ClearanceLevel,
+      ClearanceGranted: this.props.ClearanceGranted,
       ...queue,
     })
   }
@@ -92,8 +94,17 @@ export default class HistoryItem extends ValidationElement {
     })
   }
 
+  updateClearanceGranted = (values) => {
+    this.update({
+      ClearanceGranted: values,
+      Issued: {},
+      Granted: {},
+      ClearanceLevel: {},
+    })
+  }
+
   render() {
-    const requireClearanceQuestions = true
+    const { requireLegalInvestigationClearanceGranted } = this.props
 
     return (
       <div>
@@ -150,19 +161,38 @@ export default class HistoryItem extends ValidationElement {
               {...this.props.Completed}
               onUpdate={this.updateCompleted}
               onError={this.props.onError}
-              minDateEqualTo
+              minDateEqualTo={true}
               className="legal-investigations-history-completed"
               required={this.props.required}
             />
           </NotApplicable>
         </Field>
 
-        {requireClearanceQuestions && (
+        {requireLegalInvestigationClearanceGranted && (
+          <Branch
+            label={i18n.t('legal.investigations.history.heading.wasClearanceGranted')}
+            labelSize="h4"
+            warning={true}
+            onError={this.props.onError}
+            required={this.props.required}
+            onUpdate={this.updateClearanceGranted}
+            scrollIntoView={this.props.scrollIntoView}
+            {...this.props.ClearanceGranted}
+          />
+        )}
+
+        {((
+          requireLegalInvestigationClearanceGranted
+          && this.props.ClearanceGranted
+          && this.props.ClearanceGranted.value === 'Yes'
+        ) || (
+          !requireLegalInvestigationClearanceGranted
+        )) && (
           <span>
             <Field
               title={i18n.t('legal.investigations.history.heading.issued')}
               adjustFor="text"
-              optional
+              optional={true}
               scrollIntoView={this.props.scrollIntoView}
             >
               <Text
@@ -195,7 +225,7 @@ export default class HistoryItem extends ValidationElement {
                   {...this.props.Granted}
                   onUpdate={this.updateGranted}
                   minDate={this.props.Completed}
-                  minDateEqualTo
+                  minDateEqualTo={true}
                   onError={this.props.onError}
                   className="legal-investigations-history-granted"
                   required={this.props.required}
@@ -244,4 +274,5 @@ HistoryItem.defaultProps = {
   CompletedNotApplicable: { applicable: true },
   GrantedNotApplicable: { applicable: true },
   ClearanceLevelNotApplicable: { applicable: true },
+  requireLegalInvestigationClearanceGranted: false,
 }

--- a/src/components/Section/Package/Print/index.jsx
+++ b/src/components/Section/Package/Print/index.jsx
@@ -139,16 +139,16 @@ export class PackagePrint extends React.Component {
     const { printed, attachments } = this.state
 
     const sectionComponents = {
-      [`${sections.IDENTIFICATION}`]: IdentificationReview,
-      [`${sections.HISTORY}`]: HistoryReview,
-      [`${sections.RELATIONSHIPS}`]: RelationshipsReview,
-      [`${sections.CITIZENSHIP}`]: CitizenshipReview,
-      [`${sections.MILITARY}`]: MilitaryReview,
-      [`${sections.FOREIGN}`]: ForeignReview,
-      [`${sections.FINANCIAL}`]: FinancialReview,
-      [`${sections.SUBSTANCE_USE}`]: SubstanceUseReview,
-      [`${sections.LEGAL}`]: LegalReview,
-      [`${sections.PSYCHOLOGICAL}`]: PsychologicalReview,
+      [sections.IDENTIFICATION]: IdentificationReview,
+      [sections.HISTORY]: HistoryReview,
+      [sections.RELATIONSHIPS]: RelationshipsReview,
+      [sections.CITIZENSHIP]: CitizenshipReview,
+      [sections.MILITARY]: MilitaryReview,
+      [sections.FOREIGN]: ForeignReview,
+      [sections.FINANCIAL]: FinancialReview,
+      [sections.SUBSTANCE_USE]: SubstanceUseReview,
+      [sections.LEGAL]: LegalReview,
+      [sections.PSYCHOLOGICAL]: PsychologicalReview,
     }
 
     return (
@@ -232,13 +232,15 @@ export class PackagePrint extends React.Component {
 
           {formSections.map((section) => {
             const SectionComponent = sectionComponents[section.key]
-
-            return (
-              <div className="section-print-container" key={`print-section-${section.key}`}>
-                <h3 className="section-print-header">{section.label}</h3>
-                <SectionComponent forPrint={true} />
-              </div>
-            )
+            if (SectionComponent) {
+              return (
+                <div className="section-print-container" key={`print-section-${section.key}`}>
+                  <h3 className="section-print-header">{section.label}</h3>
+                  <SectionComponent forPrint={true} />
+                </div>
+              )
+            }
+            return null
           })}
         </div>
       </div>

--- a/src/components/Section/Relationships/Relatives/Relatives.jsx
+++ b/src/components/Section/Relationships/Relatives/Relatives.jsx
@@ -35,21 +35,23 @@ export class Relatives extends Subsection {
     this.storeKey = storeKey
   }
 
-  getSectionErrors = () => {
+  // These are warnings so create a work around for applicants
+  // that don't know their mother/father.
+  getSectionWarnings = () => {
     const { errors = [], maritalStatus } = this.props
     const errorList = {
       'List.containsRequiredItems.REQUIREMENT_NOT_MET': {
         errors: [
           {
             key: 'relatives-mother-father-required-error',
-            title: i18n.t('error.validRelation.title'),
-            message: i18n.t('error.validRelation.message'),
+            title: i18n.t('error.validRelationWarning.title'),
+            message: i18n.t('error.validRelationWarning.message'),
             shouldDisplayError: true,
           },
           {
             key: 'relatives-mil-fil-required-error',
-            title: i18n.t('error.validMaritalRelation.title'),
-            message: i18n.t('error.validMaritalRelation.message'),
+            title: i18n.t('error.validMaritalRelationWarning.title'),
+            message: i18n.t('error.validMaritalRelationWarning.message'),
             shouldDisplayError: (
               [MARRIED, SEPARATED].includes(maritalStatus)
             ),
@@ -134,7 +136,10 @@ export class Relatives extends Subsection {
         </Field>
 
         {List.branch && List.branch.value === 'No' && (
-          <ErrorMessageList errors={this.getSectionErrors()} />
+          <ErrorMessageList
+            errors={this.getSectionWarnings()}
+            isWarning={true}
+          />
         )}
 
         <Accordion

--- a/src/components/Summary/TelephoneSummary.js
+++ b/src/components/Summary/TelephoneSummary.js
@@ -11,7 +11,7 @@ export const TelephoneSummary = (props, unknown = '') => {
 
     switch (props.type) {
       case 'International':
-        number = `+${number.slice(0, 3).trim()} ${number.slice(3, 13).trim()}`
+        number = `+${number.trim()}`
         if (props.extension) {
           number += ` x${props.extension}`
         }

--- a/src/components/Summary/TelephoneSummary.test.js
+++ b/src/components/Summary/TelephoneSummary.test.js
@@ -16,7 +16,7 @@ describe('The telephone summary', () => {
     }
     const summary = TelephoneSummary(phone, 'Unknown')
     expect(summary).toEqual(
-      <span className="title-case">+001 1234567890 x1234</span>
+      <span className="title-case">+0011234567890 x1234</span>
     )
   })
 

--- a/src/config/locales/en/error.js
+++ b/src/config/locales/en/error.js
@@ -75,9 +75,8 @@ export const error = {
     age: {
       title: 'The applicant age is not approved',
       message: [
-        'Your date of birth indicates you are under the age of 16, please confirm the date is correct using the button below.',
-        '*or*',
-        'Applicants must be younger than 130 years old.',
+        'Your date of birth indicates you are under the age of 16 or over 100.',
+        'Please confirm the date is correct by checking the box below.'
       ],
       note: '',
     },

--- a/src/config/locales/en/error.js
+++ b/src/config/locales/en/error.js
@@ -1198,10 +1198,18 @@ export const error = {
     message:
       'You indicated that you are married or separated, please provide entries for mother-in-law and father-in-law.',
   },
+  validMaritalRelationWarning: {
+    title: 'Information for mother-in-law and father-in-law must be provided',
+    message: 'If you do not know your mother and/or father in-law, please enter as much information as possible for the required fields.',
+  },
   validRelation: {
     title: 'Mother and father must be provided',
     message:
       'If you do not know your mother or father, please enter "I don\'t know" and provide a comment explaining your relationship.',
+  },
+  validRelationWarning: {
+    title: 'Information for mother and father must be provided',
+    message: 'If you do not know your mother and/or father, please enter as much information as possible for the required fields.',
   },
   validPhoneTypes: {
     title: 'There is a problem with your phone numbers',

--- a/src/config/locales/en/error.js
+++ b/src/config/locales/en/error.js
@@ -767,6 +767,11 @@ export const error = {
           message: 'City name should be between 2 and 100 characters.',
           note: '',
         },
+        required: {
+          title: 'There is a problem with the City',
+          message: 'City is required if County is not filled in',
+          note: '',
+        }
       },
       state: {
         notfound: {
@@ -785,6 +790,11 @@ export const error = {
           message: 'County name must be between 2 and 100 characters',
           note: '',
         },
+        required: {
+          title: 'There is a problem with the County',
+          message: 'County is required if City is not filled in',
+          note: '',
+        }
       },
       zipcode: {
         pattern: {
@@ -1045,33 +1055,15 @@ export const error = {
     international: {
       first: {
         pattern: {
-          title: 'There is a problem with this country code',
-          message:
-            'The country code of the international number should be 3 digits between 0 and 9.',
-          note: '',
-        },
-        length: {
-          title: 'There is a problem with this country code',
-          message:
-            'The country code of the international number should be 3 digits between 0 and 9.',
-          note: '',
-        },
-        required: {
-          title: 'Your response is required',
-          message: '',
-        },
-      },
-      second: {
-        pattern: {
           title: 'There is a problem with this number',
           message:
-            'The international number should be 10 digits between 0 and 9.',
+            'The international number should be 4-20 digits between 0 and 9.',
           note: '',
         },
         length: {
           title: 'There is a problem with this number',
           message:
-            'The international number should be 10 digits between 0 and 9.',
+            'The international number should be 4-20 digits between 0 and 9.',
           note: '',
         },
         required: {

--- a/src/config/locales/en/legal.js
+++ b/src/config/locales/en/legal.js
@@ -385,6 +385,7 @@ export const legal = {
       heading: {
         title:
           'Has the U.S. Government (or a foreign government) EVER investigated your background and/or granted you a security clearance eligibility/access?',
+        wasClearanceGranted: 'Was a clearance eligibility/access granted?',
         agency: 'Provide the investigating agency',
         completed: 'Date the investigation was completed',
         issued:

--- a/src/constants/dateLimits.js
+++ b/src/constants/dateLimits.js
@@ -11,11 +11,11 @@ export const DEFAULT_EARLIEST = TODAY.minus({ years: 200 })
 
 /**
  * Applicant birthdate must be:
- * - less than 130 years, 1 day ago
+ * - less than 100 years, 1 day ago
  * - more than 16 years ago
  */
 export const SELF = {
-  earliest: TODAY.minus({ years: 130, days: 1 }),
+  earliest: TODAY.minus({ years: 100, days: 1 }),
   latest: TODAY.minus({ years: 16 }),
 }
 

--- a/src/models/investigation.js
+++ b/src/models/investigation.js
@@ -1,4 +1,4 @@
-import { checkValueIncluded } from 'models/validate'
+import { checkValueIncluded, hasYesOrNo } from 'models/validate'
 import { US_DEPT_OF_TREASURY, FOREIGN_GOVT, OTHER } from 'constants/enums/legalOptions'
 import { DEFAULT_LATEST } from 'constants/dateLimits'
 
@@ -37,18 +37,44 @@ const investigation = {
     return { presence: true, date: true }
   },
   Issued: {},
-  Granted: (value, attributes) => {
+  Granted: (value, attributes, attributeName, options) => {
     if (attributes.GrantedNotApplicable
       && attributes.GrantedNotApplicable.applicable === false) {
       return {}
     }
+
+    if (
+      options.requireLegalInvestigationClearanceGranted
+      && attributes.ClearanceGranted
+      && attributes.ClearanceGranted.value === 'No'
+    ) {
+      return {}
+    }
+
     const dateLimits = { latest: DEFAULT_LATEST }
     if (attributes.Completed) dateLimits.earliest = attributes.Completed
     return { presence: true, date: dateLimits }
   },
-  ClearanceLevel: (value, attributes) => {
+  ClearanceGranted: (value, attributes, attributeName, options) => {
+    if (options.requireLegalInvestigationClearanceGranted) {
+      return {
+        presence: true,
+        hasValue: { validator: hasYesOrNo },
+      }
+    }
+    return {}
+  },
+  ClearanceLevel: (value, attributes, attributeName, options) => {
     if (attributes.ClearanceLevelNotApplicable
       && attributes.ClearanceLevelNotApplicable.applicable === false) {
+      return {}
+    }
+
+    if (
+      options.requireLegalInvestigationClearanceGranted
+      && attributes.ClearanceGranted
+      && attributes.ClearanceGranted.value === 'No'
+    ) {
       return {}
     }
 

--- a/src/models/sections/__tests__/identificationDateOfBirth.test.js
+++ b/src/models/sections/__tests__/identificationDateOfBirth.test.js
@@ -25,14 +25,14 @@ describe('The identification date of birth section', () => {
       .toEqual(expect.arrayContaining(expectedErrors))
   })
 
-  it('requires a birthdate less than 130 years and 1 day', () => {
+  it('requires a birthdate less than 100 years and 1 day', () => {
     const currentYear = new Date().getFullYear()
 
     const testData = {
       Date: {
         month: '1',
         day: '1',
-        year: currentYear - 130,
+        year: currentYear - 100,
         estimated: false,
       },
     }

--- a/src/models/sections/__tests__/identificationPlaceOfBirth.test.js
+++ b/src/models/sections/__tests__/identificationPlaceOfBirth.test.js
@@ -22,6 +22,30 @@ describe('The identification place of birth section', () => {
     expect(validateModel(testData, identificationPlaceOfBirth)).toEqual(true)
   })
 
+  it('validates a domestic place of birth with county only', () => {
+    const testData = {
+      Location: {
+        country: { value: 'United States' },
+        state: 'CA',
+        county: 'Los Angeles',
+      },
+    }
+
+    expect(validateModel(testData, identificationPlaceOfBirth)).toEqual(true)
+  })
+
+  it('validates a domestic place of birth with city only', () => {
+    const testData = {
+      Location: {
+        country: { value: 'United States' },
+        city: 'Los Angeles',
+        state: 'CA',
+      },
+    }
+
+    expect(validateModel(testData, identificationPlaceOfBirth)).toEqual(true)
+  })
+
   it('validates an international place of birth', () => {
     const testData = {
       Location: {

--- a/src/models/sections/identificationPlaceOfBirth.js
+++ b/src/models/sections/identificationPlaceOfBirth.js
@@ -2,9 +2,14 @@
 import birthplace from 'models/shared/locations/birthplace'
 
 const identificationPlaceOfBirth = {
-  Location: {
-    presence: true,
-    location: { validator: birthplace },
+  Location: (value, attributes) => {
+
+    return {
+      presence: true,
+      location: {
+        validator: birthplace, requireCity: value ? !value.county : true, requireCounty: value ? !value.city : true
+      }
+    }
   },
 }
 

--- a/src/models/shared/__tests__/phone.test.js
+++ b/src/models/shared/__tests__/phone.test.js
@@ -101,10 +101,22 @@ describe('The phone model', () => {
   })
 
   describe('for International numbers', () => {
-    it('number must be more than 10 digits', () => {
+    it('number must be more than 3 digits', () => {
       const testData = {
         type: 'International',
-        number: '1234567890',
+        number: '123',
+      }
+
+      const expectedErrors = ['number.format.INVALID_FORMAT']
+
+      expect(validateModel(testData, phone))
+        .toEqual(expect.arrayContaining(expectedErrors))
+    })
+
+    it('number must be less than 21 digits', () => {
+      const testData = {
+        type: 'International',
+        number: '123456789012345678901',
       }
 
       const expectedErrors = ['number.format.INVALID_FORMAT']

--- a/src/models/shared/locations/__tests__/birthplace.test.js
+++ b/src/models/shared/locations/__tests__/birthplace.test.js
@@ -27,14 +27,6 @@ describe('The location/birthplace model', () => {
         .toEqual(expect.arrayContaining(expectedErrors))
     })
 
-    it('county is required', () => {
-      const testData = { state: 'NY', country: 'United States' }
-      const expectedErrors = ['county.presence.REQUIRED']
-
-      expect(validateModel(testData, birthplace))
-        .toEqual(expect.arrayContaining(expectedErrors))
-    })
-
     it('passes a valid domestic address', () => {
       const testData = {
         city: 'New York',
@@ -64,6 +56,35 @@ describe('The location/birthplace model', () => {
       }
 
       expect(validateModel(testData, birthplace)).toEqual(true)
+    })
+  })
+
+  describe('for set required fields', () => {
+
+    it('passes when city is not required', () => {
+      const testData = {
+        state: 'NY',
+        country: 'United States',
+        county: 'Manhattan',
+      }
+      const options = {
+        requireCity: false
+      }
+
+      expect(validateModel(testData, birthplace, options)).toEqual(true)
+    })
+
+    it('passes when county is not required', () => {
+      const testData = {
+        city: 'New York',
+        state: 'NY',
+        country: 'United States',
+      }
+      const options = {
+        requireCounty: false
+      }
+
+      expect(validateModel(testData, birthplace, options)).toEqual(true)
     })
   })
 })

--- a/src/models/shared/locations/birthplace.js
+++ b/src/models/shared/locations/birthplace.js
@@ -1,10 +1,32 @@
 import locationModel from '../location'
+import { isInternational } from 'helpers/location'
 
 const locationBirthplace = {
-  city: locationModel.city,
+  city: (value, attributes, attributeName, options) => {
+    if (options.requireCity === false)
+      return {
+        ...locationModel.city,
+        presence: false,
+      }
+    return {
+      ...locationModel.city,
+      presence: true,
+    }
+  },
   state: locationModel.state,
+
   country: locationModel.country,
-  county: locationModel.county,
+  county: (value, attributes, attributeName, options) => {
+    if (options.requireCounty === false || isInternational(attributes))
+      return {
+        ...locationModel.county,
+        presence: false,
+      }
+    return {
+      ...locationModel.county,
+      presence: true,
+    }
+  },
 }
 
 export default locationBirthplace

--- a/src/models/shared/phone.js
+++ b/src/models/shared/phone.js
@@ -43,7 +43,7 @@ const phone = {
       case 'International':
         return {
           presence: true,
-          format: { pattern: /^\d{11,}$/ },
+          format: { pattern: /^\d{4,20}$/ },
         }
       default: {
         return { presence: true }

--- a/src/schema/section/legal-investigations-history.js
+++ b/src/schema/section/legal-investigations-history.js
@@ -1,7 +1,7 @@
 import * as form from '../form'
 
 export const legalInvestigationsHistory = (data = {}) => {
-  const items = ((data.List || {}).items || []).map(x => {
+  const items = ((data.List || {}).items || []).map((x) => {
     const xitem = x.Item || {}
     return {
       Item: {
@@ -15,15 +15,16 @@ export const legalInvestigationsHistory = (data = {}) => {
         Issued: form.text(xitem.Issued),
         Granted: form.datecontrol(xitem.Granted),
         GrantedNotApplicable: form.notapplicable(xitem.GrantedNotApplicable),
+        ClearanceGranted: form.branch(xitem.ClearanceGranted),
         ClearanceLevel: form.clearancelevel(xitem.ClearanceLevel),
         ClearanceLevelNotApplicable: form.notapplicable(
           xitem.ClearanceLevelNotApplicable
-        )
-      }
+        ),
+      },
     }
   })
   return {
     HasHistory: form.branch(data.HasHistory),
-    List: form.collection(items, (data.List || {}).branch)
+    List: form.collection(items, (data.List || {}).branch),
   }
 }

--- a/src/schema/section/legal-investigations-history.test.js
+++ b/src/schema/section/legal-investigations-history.test.js
@@ -18,15 +18,16 @@ describe('Schema for financial taxes', () => {
               Issued: {},
               Granted: {},
               GrantedNotApplicable: {},
+              ClearanceGranted: {},
               ClearanceLevel: {
                 Level: {},
-                Explanation: {}
+                Explanation: {},
               },
-              ClearanceLevelNotApplicable: {}
-            }
-          }
-        ]
-      }
+              ClearanceLevelNotApplicable: {},
+            },
+          },
+        ],
+      },
     }
 
     expect(unschema(legalInvestigationsHistory(data))).toEqual(data)

--- a/src/validators/datecontrol.js
+++ b/src/validators/datecontrol.js
@@ -117,7 +117,7 @@ export const dateLimits = (relationship, birthdate) => {
   switch (relationship) {
     case 'Self':
       max = daysAgo(today, 365 * 16)
-      min = daysAgo(today, 365 * 130 + 1)
+      min = daysAgo(today, 365 * 100 + 1)
       break
     case 'Mother':
     case 'Father':

--- a/src/validators/identificationbirthplace.js
+++ b/src/validators/identificationbirthplace.js
@@ -2,6 +2,7 @@
 import { validateModel } from 'models/validate'
 import identificationPlaceOfBirth from 'models/sections/identificationPlaceOfBirth'
 
-export const validateIdentificationBirthPlace = data => (
-  validateModel(data, identificationPlaceOfBirth)
-)
+export const validateIdentificationBirthPlace = (data) => {
+
+  return validateModel(data, identificationPlaceOfBirth)
+}

--- a/src/validators/identificationbirthplace.test.js
+++ b/src/validators/identificationbirthplace.test.js
@@ -1,0 +1,71 @@
+import {
+  validateIdentificationBirthPlace,
+} from './identificationbirthplace'
+
+describe('The validateIdentificationBirthPlace function', () => {
+  it('should validate a birth place', () => {
+    const testData = {
+      Location: {
+        city: 'Boston',
+        state: 'MA',
+        county: 'Boston',
+        country: 'United States',
+      },
+    }
+
+    expect(validateIdentificationBirthPlace(testData)).toBe(true)
+  })
+
+  it('should validate a domestic birth place with city and state', () => {
+    const testData = {
+      Location: {
+        city: 'Boston',
+        state: 'MA',
+        country: 'United States',
+      },
+    }
+
+    expect(validateIdentificationBirthPlace(testData)).toBe(true)
+  })
+
+  it('should validate a domestic birth place with county and state', () => {
+    const testData = {
+      Location: {
+        state: 'MA',
+        county: 'Boston',
+        country: 'United States',
+      },
+    }
+
+    expect(validateIdentificationBirthPlace(testData)).toBe(true)
+  })
+
+  it('should validate a foreign birth place', () => {
+    const testData = {
+      Location: {
+        city: 'Toronto',
+        country: {
+          value: ['Canada'],
+        },
+      },
+    }
+
+    expect(validateIdentificationBirthPlace(testData)).toBe(true)
+  })
+
+  it('should fail an invalid birth place', () => {
+    const testData = {
+      Location: {
+        state: 'MA',
+        country: '',
+      },
+    }
+
+    expect(validateIdentificationBirthPlace(testData))
+      .toEqual(expect.arrayContaining([
+        'Location.location.city.presence.REQUIRED',
+        'Location.location.country.presence.REQUIRED',
+        'Location.location.county.presence.REQUIRED',
+      ]))
+  })
+})

--- a/src/validators/legalinvestigationshistory.js
+++ b/src/validators/legalinvestigationshistory.js
@@ -1,11 +1,15 @@
+import store from 'services/store'
 import { validateModel, hasYesOrNo } from 'models/validate'
 import investigation from 'models/investigation'
+import { requireLegalInvestigationClearanceGranted } from 'helpers/branches'
 
-export const validateInvestigation = data => (
-  validateModel(data, investigation)
+export const validateInvestigation = (data, formType) => (
+  validateModel(data, investigation, {
+    requireLegalInvestigationClearanceGranted: requireLegalInvestigationClearanceGranted(formType),
+  })
 )
 
-export const validateLegalInvestigationsHistory = (data) => {
+export const validateLegalInvestigationsHistory = (data, formType) => {
   const legalInvestigationsHistoryModel = {
     HasHistory: { presence: true, hasValue: { validator: hasYesOrNo } },
     List: (value, attributes) => {
@@ -18,25 +22,34 @@ export const validateLegalInvestigationsHistory = (data) => {
       return {}
     },
   }
+  const options = {
+    requireLegalInvestigationClearanceGranted: requireLegalInvestigationClearanceGranted(formType),
+  }
 
-  return validateModel(data, legalInvestigationsHistoryModel)
+  return validateModel(data, legalInvestigationsHistoryModel, options)
 }
 
 export default class LegalInvestigationsHistoryValidator {
   constructor(data = {}) {
+    const state = store.getState()
+    const { formType } = state.application.Settings
     this.data = data
     this.hasHistory = (data.HasHistory || {}).value
     this.list = data.List || {}
+    this.formType = formType
   }
 
   isValid() {
-    return validateLegalInvestigationsHistory(this.data) === true
+    return validateLegalInvestigationsHistory(this.data, this.formType) === true
   }
 }
 
 export class HistoryValidator {
   constructor(data = {}) {
+    const state = store.getState()
+    const { formType } = state.application.Settings
     this.data = data
+    this.formType = formType
   }
 
   validAgency() {
@@ -65,6 +78,6 @@ export class HistoryValidator {
   }
 
   isValid() {
-    return validateInvestigation(this.data) === true
+    return validateInvestigation(this.data, this.formType) === true
   }
 }

--- a/src/validators/location.js
+++ b/src/validators/location.js
@@ -278,7 +278,10 @@ export default class LocationValidator {
           valid = valid && this.validStreet()
           break
         case 'city':
-          valid = valid && this.validCity()
+          if (this.layout === Layouts.IDENTIFICATION_BIRTH_PLACE)
+            valid = valid && (this.validCity() || this.validCounty())
+          else
+            valid = valid && this.validCity()
           break
         case 'state':
           valid = valid && this.validState()
@@ -290,7 +293,10 @@ export default class LocationValidator {
           valid = valid && this.validZipcodeState()
           break
         case 'county':
-          valid = valid && this.validCounty()
+          if (this.layout === Layouts.IDENTIFICATION_BIRTH_PLACE)
+            valid = valid && (this.validCity() || this.validCounty())
+          else
+            valid = valid && this.validCounty()
           break
         case 'country':
           valid = valid && this.validCountry()


### PR DESCRIPTION
## Description

This PR changes the max age validation in identification date of birth from 130 to 100.

To reproduce this issue, when entering into e-QIP an applicant over 100 years old, e-QIP does not prohibit applicants over age of 100 instead it prohibits only when age is over 130. 

Implement the following logic (extracted from the e-QIP Validation Matrix):
Date must be greater than or equal to NOW-100. Date must be less than or equal to NOW.

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
