### PR TITLE
[EN-3927] Fix missing country bug

### DIFF
--- a/api/location.go
+++ b/api/location.go
@@ -39,14 +39,14 @@ const (
 // Location is a basic input.
 type Location struct {
 	ID              int    `json:"-"`
-	Layout          string `json:"layout"`
+	Layout          string `json:"layout,omitempty"`
 	Street1         string `json:"street,omitempty"`
 	Street2         string `json:"street2,omitempty"`
 	City            string `json:"city,omitempty"`
 	State           string `json:"state,omitempty"`
 	Zipcode         string `json:"zipcode,omitempty"`
 	County          string `json:"county,omitempty"`
-	Country         string `json:"country"`
+	Country         string `json:"country,omitempty"`
 	CountryComments string `json:"countryComments,omitempty"`
 	Validated       bool   `json:"validated,omitempty"`
 }
@@ -209,6 +209,7 @@ func has(target string, options ...string) bool {
 
 	return false
 }
+
 // IsDomestic returns whether the location is in the United States.
 func (entity *Location) IsDomestic() bool {
 	return entity.Country == "United States" || entity.Layout == LayoutUSAddress

--- a/api/testdata/citizenship/citizenship-passports.json
+++ b/api/testdata/citizenship/citizenship-passports.json
@@ -166,10 +166,7 @@
               },
               "Location": {
                 "type": "location",
-                "props": {
-                  "layout": "",
-                  "country": ""
-                }
+                "props": {}
               },
               "Name": {
                 "type": "name",

--- a/api/testdata/citizenship/citizenship-status.json
+++ b/api/testdata/citizenship/citizenship-status.json
@@ -65,10 +65,7 @@
     },
     "PlaceIssued": {
       "type": "location",
-      "props": {
-        "country": "",
-        "layout": ""
-      }
+      "props": {}
     },
     "CertificateNumber": {
       "type": "text",
@@ -106,10 +103,7 @@
     },
     "CertificateCourtAddress": {
       "type": "location",
-      "props": {
-        "country": "",
-        "layout": ""
-      }
+      "props": {}
     },
     "BornOnMilitaryInstallation": {
       "type": "branch",
@@ -134,10 +128,7 @@
     },
     "EntryLocation": {
       "type": "location",
-      "props": {
-        "country": "",
-        "layout": ""
-      }
+      "props": {}
     },
     "PriorCitizenship": {
       "type": "country",

--- a/api/testdata/history/history-employment-full.json
+++ b/api/testdata/history/history-employment-full.json
@@ -134,10 +134,7 @@
                   },
                   "Address": {
                     "type": "location",
-                    "props": {
-                      "layout": "",
-                      "country": ""
-                    }
+                    "props": {}
                   },
                   "Telephone": {
                     "type": "telephone",
@@ -212,10 +209,7 @@
               },
               "ReferenceAddress": {
                 "type": "location",
-                "props": {
-                  "layout": "",
-                  "country": ""
-                }
+                "props": {}
               },
               "ReferenceName": {
                 "type": "name",

--- a/api/testdata/legal/legal-police-offenses.json
+++ b/api/testdata/legal/legal-police-offenses.json
@@ -292,10 +292,7 @@
               },
               "CourtAddress": {
                 "type": "location",
-                "props": {
-                  "layout": "",
-                  "country": ""
-                }
+                "props": {}
               },
               "CourtCharge": {
                 "type": "text",

--- a/api/testdata/military/military-history.json
+++ b/api/testdata/military/military-history.json
@@ -101,8 +101,7 @@
                 "type": "location",
                 "props": {
                   "layout": "State",
-                  "state": "AZ",
-                  "country": ""
+                  "state": "AZ"
                 }
               },
               "Status": {

--- a/api/testdata/psychological/psychological-competence.json
+++ b/api/testdata/psychological/psychological-competence.json
@@ -63,10 +63,7 @@
                       "Item": {
                         "CourtAddress": {
                           "type": "location",
-                          "props": {
-                            "layout": "",
-                            "country": ""
-                          }
+                          "props": {}
                         },
                         "CourtName": {
                           "type": "text",
@@ -132,10 +129,7 @@
                       "Item": {
                         "CourtAddress": {
                           "type": "location",
-                          "props": {
-                            "layout": "",
-                            "country": ""
-                          }
+                          "props": {}
                         },
                         "CourtName": {
                           "type": "text",

--- a/src/components/Form/Location/Location.jsx
+++ b/src/components/Form/Location/Location.jsx
@@ -15,6 +15,8 @@ import ZipCode from 'components/Form/ZipCode'
 import Spinner, { SpinnerAction } from 'components/Form/Spinner'
 import Suggestions from 'components/Form/Suggestions'
 
+import { countryValueResolver } from 'helpers/location'
+
 import Address from './Address'
 import ToggleableLocation from './ToggleableLocation'
 import { AddressSuggestion } from './AddressSuggestion'
@@ -26,18 +28,6 @@ export const timeout = (fn, milliseconds = 400, w = window) => {
   }
 
   w.setTimeout(fn, milliseconds)
-}
-
-export const countryValueResolver = (props) => {
-  if (typeof props.country === 'string') {
-    const valueArr = props.country ? [props.country] : []
-    const comments = props.countryComments || ''
-    return {
-      value: valueArr,
-      comments,
-    }
-  }
-  return props.country
 }
 
 export default class Location extends ValidationElement {
@@ -563,7 +553,7 @@ export default class Location extends ValidationElement {
               key={field}
               className="street2"
               label={this.props.street2Label}
-              optional
+              optional={true}
               value={this.props.street2}
               disabled={this.props.disabled}
               onUpdate={this.updateStreet2}

--- a/src/components/Form/Location/Location.test.jsx
+++ b/src/components/Form/Location/Location.test.jsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { mount } from 'enzyme'
-import Location, { timeout, countryValueResolver } from './Location'
+
+import { countryValueResolver } from 'helpers/location'
+import Location, { timeout } from './Location'
 
 describe('The Address component', () => {
   it('Renders without errors', () => {

--- a/src/components/Form/Location/ToggleableLocation.jsx
+++ b/src/components/Form/Location/ToggleableLocation.jsx
@@ -1,6 +1,10 @@
 import React from 'react'
-import { env, i18n } from '../../../config'
-import Branch from '../Branch';
+
+import { env, i18n } from 'config'
+import { countryValueResolver } from 'helpers/location'
+import LocationValidator, { countryString } from 'validators/location'
+
+import Branch from '../Branch'
 import ValidationElement from '../ValidationElement'
 import Street from '../Street'
 import State from '../State'
@@ -9,17 +13,37 @@ import Country from '../Country'
 import County from '../County'
 import ZipCode from '../ZipCode'
 import Show from '../Show'
-import { country, countryValueResolver } from './Location'
-import LocationValidator, { countryString } from '../../../validators/location'
 import Layouts from './Layouts'
 
-const mappingWarning = property => {
+const mappingWarning = (property) => {
   if (!env.IsTest()) {
     console.warn(
       `Could not map location property '${property}' in ToggleableLocation `
     )
   }
 }
+
+const branchValue = (value) => {
+  let country = value
+
+  if (typeof country === 'object') {
+    country = countryString(value)
+    if (country === '') return 'No'
+    if (country === null) return ''
+  }
+
+  switch (country) {
+    case 'United States':
+      return 'Yes'
+    case '':
+      return ''
+    default:
+      // For all other cases, country is an empty string (user intends to select country) or
+      // user has selected a country
+      return 'No'
+  }
+}
+
 
 export default class ToggleableLocation extends ValidationElement {
   constructor(props) {
@@ -37,14 +61,14 @@ export default class ToggleableLocation extends ValidationElement {
     this.addressType = this.addressType.bind(this)
     this.state = {
       suggestions: [],
-      uid: `${this.props.name}-${super.guid()}`
+      uid: `${this.props.name}-${super.guid()}`,
     }
     this.errors = []
   }
 
   update(updateValues) {
     if (this.props.onUpdate) {
-      this.props.onUpdate({
+      const nextValues = {
         street: this.props.street,
         city: this.props.city,
         zipcode: this.props.zipcode,
@@ -55,8 +79,14 @@ export default class ToggleableLocation extends ValidationElement {
         domestic: this.props.domestic,
         domesticFields: this.props.domesticFields,
         internationalFields: this.props.internationalFields,
-        ...updateValues
-      })
+        ...updateValues,
+      }
+
+      if (!nextValues.country && this.addressType() === 'United States') {
+        nextValues.country = { value: 'United States' }
+      }
+
+      this.props.onUpdate(nextValues)
     }
   }
 
@@ -75,7 +105,7 @@ export default class ToggleableLocation extends ValidationElement {
   updateCountry(values) {
     this.update({
       country: values,
-      countryComments: values.comments
+      countryComments: values.comments,
     })
   }
 
@@ -91,13 +121,11 @@ export default class ToggleableLocation extends ValidationElement {
     // Set existing errors to null when toggling fields
     this.props.onError(
       option.value,
-      this.errors.map(err => {
-        return {
-          code: err.code,
-          valid: null,
-          uid: err.uid
-        }
-      })
+      this.errors.map(err => ({
+        code: err.code,
+        valid: null,
+        uid: err.uid,
+      }))
     )
 
     switch (option.value) {
@@ -107,6 +135,7 @@ export default class ToggleableLocation extends ValidationElement {
       case 'No':
         this.update({ country: { value: '' } })
         break
+      default:
     }
   }
 
@@ -117,26 +146,24 @@ export default class ToggleableLocation extends ValidationElement {
   }
 
   addressType() {
-    let country = this.props.country
+    let { country } = this.props
+
     if (typeof country === 'object') {
       country = countryString(country)
-      if (country === '') {
-        return 'International'
-      }
+      if (country === '') return 'International'
     }
 
-    if (country === '') {
-      return ''
-    } else if (country === 'United States') {
-      return country
-    } else if (country) {
-      return 'International'
-    }
+    if (country === '') return ''
+    if (country === 'United States') return country
+    if (country) return 'International'
+
+    return ''
   }
 
   render() {
     const instateZipcode = this.zipcodeInstate()
-    const domesticFields = this.props.domesticFields.map(field => {
+
+    const domesticFields = this.props.domesticFields.map((field) => {
       const key = `domestic-${field}`
       switch (field) {
         case 'street':
@@ -167,8 +194,10 @@ export default class ToggleableLocation extends ValidationElement {
               onError={this.onError}
               onFocus={this.props.onFocus}
               onBlur={this.props.onBlur}
-              required={this.props.layout === Layouts.IDENTIFICATION_BIRTH_PLACE ? this.props.required && !this.props.county : this.props.required}
-              requireCity={this.props.layout === Layouts.IDENTIFICATION_BIRTH_PLACE ? this.props.required && !this.props.county : this.props.required}
+              required={this.props.layout === Layouts.IDENTIFICATION_BIRTH_PLACE
+                ? this.props.required && !this.props.county : this.props.required}
+              requireCity={this.props.layout === Layouts.IDENTIFICATION_BIRTH_PLACE
+                ? this.props.required && !this.props.county : this.props.required}
             />
           )
         case 'county':
@@ -185,8 +214,10 @@ export default class ToggleableLocation extends ValidationElement {
               onError={this.onError}
               onBlur={this.props.onBlur}
               onFocus={this.props.onFocus}
-              required={this.props.layout === Layouts.IDENTIFICATION_BIRTH_PLACE ? this.props.required && !this.props.city : this.props.required}
-              requireCounty={this.props.layout === Layouts.IDENTIFICATION_BIRTH_PLACE ? this.props.required && !this.props.city : this.props.required}
+              required={this.props.layout === Layouts.IDENTIFICATION_BIRTH_PLACE
+                ? this.props.required && !this.props.city : this.props.required}
+              requireCounty={this.props.layout === Layouts.IDENTIFICATION_BIRTH_PLACE
+                ? this.props.required && !this.props.city : this.props.required}
             />
           )
         case 'state':
@@ -238,10 +269,12 @@ export default class ToggleableLocation extends ValidationElement {
               />
             </div>
           )
+        default:
+          return null
       }
     })
 
-    const internationalFields = this.props.internationalFields.map(field => {
+    const internationalFields = this.props.internationalFields.map((field) => {
       const key = `domestic-${field}`
       switch (field) {
         case 'city':
@@ -277,10 +310,11 @@ export default class ToggleableLocation extends ValidationElement {
               required={this.props.required}
             />
           )
+        default:
+          return null
       }
     })
 
-    const countryName = countryString(this.props.country)
     return (
       <div className="toggleable-location">
         <Branch
@@ -304,22 +338,19 @@ export default class ToggleableLocation extends ValidationElement {
   }
 
   onError(value, arr) {
-    arr = arr.map(err => {
-      return {
-        code: `toggleablelocation.${err.code}`,
-        valid: err.valid,
-        uid: err.uid
-      }
-    })
+    // eslint-disable-next-line no-param-reassign
+    arr = arr.map(err => ({
+      code: `toggleablelocation.${err.code}`,
+      valid: err.valid,
+      uid: err.uid,
+    }))
 
     const requiredErr = arr.concat(
-      this.constructor.errors.map(err => {
-        return {
-          code: `toggleablelocation.${err.code}`,
-          valid: err.func(value, { ...this.props }),
-          uid: this.state.uid
-        }
-      })
+      this.constructor.errors.map(err => ({
+        code: `toggleablelocation.${err.code}`,
+        valid: err.func(value, { ...this.props }),
+        uid: this.state.uid,
+      }))
     )
 
     this.storeErrors(requiredErr)
@@ -328,11 +359,11 @@ export default class ToggleableLocation extends ValidationElement {
   }
 
   storeErrors(errors) {
-    let newErrors = [...errors]
-    for (const e of newErrors) {
-      const idx = this.errors.findIndex(
-        x => x.uid === e.uid && x.code === e.code
-      )
+    const newErrors = [...errors]
+
+    for (let i = 0; i < newErrors.length; i += 1) {
+      const e = newErrors[i]
+      const idx = this.errors.findIndex(x => x.uid === e.uid && x.code === e.code)
       if (idx !== -1) {
         this.errors[idx] = { ...e }
       } else {
@@ -342,38 +373,13 @@ export default class ToggleableLocation extends ValidationElement {
   }
 }
 
-const branchValue = value => {
-  let country = value
-  if (typeof country === 'object') {
-    country = countryString(value)
-    if (country === '') {
-      return 'No'
-    } else if (country === null) {
-      return ''
-    }
-  }
-
-  switch (country) {
-    case 'United States':
-      return 'Yes'
-    case '':
-      return ''
-    default:
-      // For all other cases, country is an empty string (user intends to select country) or
-      // user has selected a country
-      return 'No'
-  }
-}
-
 ToggleableLocation.defaultProps = {
   country: { value: null },
   domesticFields: [],
   internationalFields: [],
-  onError: (value, arr) => {
-    return arr
-  },
+  onError: (value, arr) => arr,
   required: false,
-  scrollIntoView: false
+  scrollIntoView: false,
 }
 
 ToggleableLocation.errors = [
@@ -383,22 +389,30 @@ ToggleableLocation.errors = [
       if (!props.required) {
         return true
       }
-      
+
       // Organizing the validation tests in a structure
       const branchValidations = {
         Yes: {
-          fields: props => props.domesticFields,
-          city: props => props.layout === Layouts.IDENTIFICATION_BIRTH_PLACE ? !!props.city || !!props.county : !!props.city,
-          state: props => !!props.state,
-          county: props => props.layout === Layouts.IDENTIFICATION_BIRTH_PLACE ? !!props.city || !!props.county : !!props.county,
-          stateZipcode: props => !!props.state && !!props.zipcode,
-          country: props => !!countryString(props.country)
+          fields: p => p.domesticFields,
+          city: p => (
+            p.layout === Layouts.IDENTIFICATION_BIRTH_PLACE
+              ? !!p.city || !!p.county
+              : !!p.city
+          ),
+          state: p => !!p.state,
+          county: p => (
+            p.layout === Layouts.IDENTIFICATION_BIRTH_PLACE
+              ? !!p.city || !!p.county
+              : !!p.county
+          ),
+          stateZipcode: p => !!p.state && !!p.zipcode,
+          country: p => !!countryString(p.country),
         },
         No: {
-          fields: props => props.internationalFields,
-          city: props => !!props.city,
-          country: props => !!countryString(props.country)
-        }
+          fields: p => p.internationalFields,
+          city: p => !!p.city,
+          country: p => !!countryString(p.country),
+        },
       }
 
       // Retrieve the branch value provided. If the value does match the
@@ -410,9 +424,10 @@ ToggleableLocation.errors = [
       }
 
       // Loop through all of the fields based on the branch and test for values.
-      for (let f of validations.fields(props)) {
+      for (let i = 0; i < validations.fields(props).length; i += 1) {
+        const f = validations.fields(props)[i]
         // Retrieve the test and if one is not found print a warning and continue
-        let test = validations[f]
+        const test = validations[f]
         if (!test) {
           mappingWarning(f)
           return false
@@ -424,6 +439,6 @@ ToggleableLocation.errors = [
       }
 
       return true
-    }
-  }
+    },
+  },
 ]

--- a/src/helpers/location.js
+++ b/src/helpers/location.js
@@ -12,3 +12,15 @@ export const isUS = location => (
 export const isInternational = location => (
   location && location.country && (!isPO(location) && !isUS(location))
 )
+
+export const countryValueResolver = (props) => {
+  if (typeof props.country === 'string') {
+    const valueArr = props.country ? [props.country] : []
+    const comments = props.countryComments || ''
+    return {
+      value: valueArr,
+      comments,
+    }
+  }
+  return props.country
+}


### PR DESCRIPTION
## Description

To reproduce the issue:
1) Log in as a brand new user with no data (B/E sends no form data, everything is empty)
2) Navigate to a section such as People who know you well. Observe that the phone number fields time of day value defaults to “Both”. Do not interact with any fields
3) Navigate to another section. This triggers a save call to the B/E, which saves an “empty” version of the section that you were just one, which contains empty string values for the country, timeOfDay, etc. This is key
4) Log out/log back in. Now the B/E sends that empty data back in and the form is pre-filled with it, and those empty strings overwrite the defaults for country, timeOfDay, etc. If you go to Relationships / People, now you will see that the phone number time of day field has no default selected.

To resolve, I updated the `Location.go` struct so that it does not send an empty string value for Country fields. This was overwriting the default prop of United States in Location React components, and explicitly setting country to be an empty string.

Additionally just to be safe, I added logic to the update functions for Location components so that if a location value is being updated and is missing a country value and is displaying the domestic country UI, it always sends the United States value as a default.

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
