### PR TITLE
Fix improper naming of US Passport Expiration field

### DIFF
--- a/src/components/Section/Citizenship/UsPassport/index.jsx
+++ b/src/components/Section/Citizenship/UsPassport/index.jsx
@@ -88,7 +88,7 @@ export class UsPassport extends Subsection {
       Name: values.value === 'Yes' ? this.props.Name : {},
       Number: values.value === 'Yes' ? this.props.Number : '',
       Issued: values.value === 'Yes' ? this.props.Issued : {},
-      Expired: values.value === 'Yes' ? this.props.Expired : {},
+      Expiration: values.value === 'Yes' ? this.props.Expiration : {},
     })
   }
 


### PR DESCRIPTION
## Description

Field in Redux was previously named as `Expired` instead of `Expiration` so they field wasn't getting cleared out properly.

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
