### PR TITLE
fix validation logic for employment APO/FPO (AlternativeAddress)

### DIFF
--- a/src/models/__tests__/employment.test.js
+++ b/src/models/__tests__/employment.test.js
@@ -885,6 +885,10 @@ describe('The employment model', () => {
       it('AlternateAddress is required', () => {
         const testData = {
           EmploymentActivity: { value: 'SelfEmployment' },
+          PhysicalAddress: {
+            HasDifferentAddress: { value: 'No' },
+            Address: {},
+          },
           Address: {
             street: '123 Test St',
             city: 'London',
@@ -906,6 +910,10 @@ describe('The employment model', () => {
               street: '123 Test St',
               city: 'London',
               country: { value: 'United Kingdom' },
+            },
+            PhysicalAddress: {
+              HasDifferentAddress: { value: 'No' },
+              Address: {},
             },
             AlternateAddress: {
               HasDifferentAddress: { value: 'Yes' },
@@ -1965,6 +1973,10 @@ describe('The employment model', () => {
       it('AlternateAddress is required', () => {
         const testData = {
           EmploymentActivity: { value: 'ActiveMilitary' },
+          PhysicalAddress: {
+            HasDifferentAddress: { value: 'No' },
+            Address: {},
+          },
           Address: {
             street: '123 Test St',
             city: 'London',
@@ -1986,6 +1998,10 @@ describe('The employment model', () => {
               street: '123 Test St',
               city: 'London',
               country: { value: 'United Kingdom' },
+            },
+            PhysicalAddress: {
+              HasDifferentAddress: { value: 'No' },
+              Address: {},
             },
             AlternateAddress: {
               HasDifferentAddress: { value: 'Yes' },
@@ -2126,6 +2142,10 @@ describe('The employment model', () => {
             zipcode: '34035',
             country: 'POSTOFFICE',
           },
+          PhysicalAddress: {
+            HasDifferentAddress: { value: 'No' },
+            Address: {},
+          },
         }
 
         const expectedErrors = ['AlternateAddress.presence.REQUIRED']
@@ -2142,6 +2162,10 @@ describe('The employment model', () => {
             state: 'AA',
             zipcode: '34035',
             country: 'POSTOFFICE',
+          },
+          PhysicalAddress: {
+            HasDifferentAddress: { value: 'No' },
+            Address: {},
           },
           AlternateAddress: {
             HasDifferentAddress: { value: 'Yes' },
@@ -2447,6 +2471,10 @@ describe('The employment model', () => {
       it('AlternateAddress is required', () => {
         const testData = {
           EmploymentActivity: { value: 'NonGovernment' },
+          PhysicalAddress: {
+            HasDifferentAddress: { value: 'No' },
+            Address: {},
+          },
           Address: {
             street: '123 Test St',
             city: 'London',
@@ -2468,6 +2496,10 @@ describe('The employment model', () => {
               street: '123 Test St',
               city: 'London',
               country: { value: 'United Kingdom' },
+            },
+            PhysicalAddress: {
+              HasDifferentAddress: { value: 'No' },
+              Address: {},
             },
             AlternateAddress: {
               HasDifferentAddress: { value: 'Yes' },
@@ -2615,6 +2647,10 @@ describe('The employment model', () => {
             zipcode: '34035',
             country: 'POSTOFFICE',
           },
+          PhysicalAddress: {
+            HasDifferentAddress: { value: 'No' },
+            Address: {},
+          },
         }
 
         const expectedErrors = ['AlternateAddress.presence.REQUIRED']
@@ -2632,6 +2668,10 @@ describe('The employment model', () => {
             state: 'AA',
             zipcode: '34035',
             country: 'POSTOFFICE',
+          },
+          PhysicalAddress: {
+            HasDifferentAddress: { value: 'No' },
+            Address: {},
           },
           AlternateAddress: {
             HasDifferentAddress: { value: 'Yes' },

--- a/src/models/employment.js
+++ b/src/models/employment.js
@@ -152,28 +152,28 @@ const employment = {
     if (
       attributes.PhysicalAddress
       && attributes.PhysicalAddress.HasDifferentAddress
-      && attributes.PhysicalAddress.HasDifferentAddress.value === 'Yes'
-    ) return {}
-
-    if (attributes.Address && isInternational(attributes.Address)) {
-      return {
-        presence: true,
-        model: {
-          validator: physicalAddress,
-          militaryAddress: true,
-          hasTelephone: false,
-        },
+      && attributes.PhysicalAddress.HasDifferentAddress.value === 'No'
+    ) {
+      if (attributes.Address && isInternational(attributes.Address)) {
+        return {
+          presence: true,
+          model: {
+            validator: physicalAddress,
+            militaryAddress: true,
+            hasTelephone: false,
+          },
+        }
       }
-    }
 
-    if (attributes.Address && isPO(attributes.Address)) {
-      return {
-        presence: true,
-        model: {
-          validator: physicalAddress,
-          militaryAddress: false,
-          hasTelephone: false,
-        },
+      if (attributes.Address && isPO(attributes.Address)) {
+        return {
+          presence: true,
+          model: {
+            validator: physicalAddress,
+            militaryAddress: false,
+            hasTelephone: false,
+          },
+        }
       }
     }
 

--- a/src/models/employment.js
+++ b/src/models/employment.js
@@ -148,6 +148,13 @@ const employment = {
     }
   },
   AlternateAddress: (value, attributes) => {
+    if (matchEmploymentActivity(attributes, [UNEMPLOYMENT])) return {}
+    if (
+      attributes.PhysicalAddress
+      && attributes.PhysicalAddress.HasDifferentAddress
+      && attributes.PhysicalAddress.HasDifferentAddress.value === 'Yes'
+    ) return {}
+
     if (attributes.Address && isInternational(attributes.Address)) {
       return {
         presence: true,


### PR DESCRIPTION
## Description
test10 wasn't validating and I narrowed down the issue to `AlternateAddress` in Redux. After consulting the validation matrix ((13A.16), I came up with these changes to pass this test case.

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)