### PR TITLE
[EN-3915] Update Relationships Relative type to clear other text field

### DIFF
--- a/src/components/Section/Relationships/People/Person.jsx
+++ b/src/components/Section/Relationships/People/Person.jsx
@@ -76,12 +76,16 @@ export default class Person extends React.Component {
       // Add the new relationship
       selected.push(relations)
     }
-
-    this.update({
+    const updateObj = {
       Relationship: {
         values: selected,
       },
-    })
+    }
+
+    if (relations === 'Other') {
+      updateObj.RelationshipOther = {}
+    }
+    this.update(updateObj)
   }
 
   updateRelationshipOther = (values) => {


### PR DESCRIPTION
This PR makes sure that the `Other` relative type text field is cleared out. Currently if you select `Other` and enters in the relative type, it persists until erased. This PR will clear out that text field when `Other` is deselected.

## Description

\[Replace this with your description, include Fixes #123 to connect to the github issue\]

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
