### PR TITLE
En 2383 confirmed date not validating properly in accordion/review summary

### DIFF
--- a/src/components/Form/DateControl/DateControl.jsx
+++ b/src/components/Form/DateControl/DateControl.jsx
@@ -314,8 +314,8 @@ class DateControl extends ValidationElement {
               ref="year"
               label="Year"
               disabled={this.state.disabled}
-              min="1000"
-              max={this.props.maxDate && this.props.maxDate.year}
+              min="0"
+              max={this.props.maxDate ? this.props.maxDate.year : null}
               maxlength="4"
               pattern={this.props.pattern}
               readonly={this.props.readonly}

--- a/src/components/Form/Number/Number.jsx
+++ b/src/components/Form/Number/Number.jsx
@@ -9,6 +9,7 @@ export default class Number extends ValidationElement {
     this.state = {
       uid: `${this.props.name}-${super.guid()}`,
       max: props.max,
+      min: props.min,
     }
 
     this.handleError = this.handleError.bind(this)
@@ -19,9 +20,10 @@ export default class Number extends ValidationElement {
       return
     }
 
-    const old = this.state.max
-    this.setState({ max: next.max, value: next.value }, () => {
-      if (old !== next.max) {
+    const oldmax = this.state.max
+    const oldmin = this.state.min
+    this.setState({ max: next.max, min: next.min, value: next.value }, () => {
+      if (oldmax !== next.max || oldmin !== next.min) {
         this.handleValidation(
           {
             fake: true,
@@ -114,6 +116,7 @@ Number.defaultProps = {
   disabled: false,
   value: '',
   max: '',
+  min: '',
   prefix: '',
   pattern: '^(\\s*|\\d+)$',
   errorCode: null,

--- a/src/components/Section/Financial/Taxes/Taxes.test.jsx
+++ b/src/components/Section/Financial/Taxes/Taxes.test.jsx
@@ -124,7 +124,7 @@ describe('The taxes component', () => {
                   estimated: false,
                   month: '1',
                   day: '1',
-                  year: '1970',
+                  year: '1000',
                 },
               },
             },

--- a/src/components/Section/History/dateranges.js
+++ b/src/components/Section/History/dateranges.js
@@ -3,6 +3,7 @@
  * Date object or null.
  */
 export const extractDate = dateObj => {
+  
   if (dateObj instanceof Date) {
     return dateObj
   }
@@ -10,8 +11,10 @@ export const extractDate = dateObj => {
   if (!dateObj || !dateObj.month || !dateObj.day || !dateObj.year) {
     return null
   }
+  var d = new Date(`${dateObj.month}/${dateObj.day}/${dateObj.year}`)
+  d.setFullYear(dateObj.year) // addresses an issue where two digit years are assumed to be in 20th or 21st centry, ex: 99 -> 1999 01 -> 2001
 
-  return new Date(`${dateObj.month}/${dateObj.day}/${dateObj.year}`)
+  return d
 }
 
 /**
@@ -186,10 +189,10 @@ export const validDate = date => {
   }
   const m = parseInt(month || 0)
   const d = parseInt(day || 0)
-  const y = parseInt(year || 0)
+  const y = parseInt(year || -1)
 
   return (
-    y > 1000 &&
+    y >= 0 &&
     y < 10000 &&
     (m > 0 && m < 13) &&
     (d > 0 && d <= daysInMonth(m, y))

--- a/src/components/Section/Identification/ApplicantBirthDate/ApplicantBirthDate.jsx
+++ b/src/components/Section/Identification/ApplicantBirthDate/ApplicantBirthDate.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { i18n } from 'config'
-
+import { TODAY } from '../../../../constants/dateLimits'
 import {
   Field, DateControl, Show, Checkbox,
 } from 'components/Form'
@@ -74,24 +74,36 @@ export class ApplicantBirthDate extends Subsection {
   handleError(value, arr) {
     let local = [...arr]
 
-    const hasMinMaxError = local.some(
-      x => x.valid === false && (x.code === 'date.min' || x.code === 'date.max')
+    //too old
+    const hasMinError = local.some(
+      x => (x.valid === false) && (x.code === 'date.min')
+    )
+    
+    //too young
+    const hasMaxError = local.some(
+      x => (x.valid === false) && (x.code === 'date.max')
     )
 
     let birthdateValid = null
     if (this.props.Confirmed && this.props.Confirmed.checked === true) birthdateValid = true
-    else if (hasMinMaxError) birthdateValid = false
+    else if (hasMinError || hasMaxError) birthdateValid = false
 
     local.push({
-      code: 'birthdate.age',
-      valid: birthdateValid,
+      code: 'birthdate.age.max',
+      valid: !hasMaxError,
+      uid: this.state.uid,
+    })
+
+    local.push({
+      code: 'birthdate.age.min',
+      valid: !hasMinError,
       uid: this.state.uid,
     })
 
     local = local.filter(x => x.code !== 'date.min' && x.code !== 'date.max')
 
     // Store the errors
-    this.setState({ errors: local, needsConfirmation: hasMinMaxError })
+    this.setState({ errors: local, needsConfirmation: hasMaxError })
 
     // Take the original and concatenate our new error values to it
     return super.handleError(value, local)
@@ -99,9 +111,9 @@ export class ApplicantBirthDate extends Subsection {
 
   confirmationError(value) {
     let local = [...this.state.errors] // eslint-disable-line
-    local = local.filter(x => x.code !== 'birthdate.age')
+    local = local.filter(x => x.code !== 'birthdate.age.max')
     local.push({
-      code: 'birthdate.age',
+      code: 'birthdate.age.max',
       valid: value,
       uid: this.state.uid,
     })
@@ -133,6 +145,8 @@ export class ApplicantBirthDate extends Subsection {
             name="birthdate"
             {...this.props.Date}
             relationship="Self"
+            
+            maxDate={TODAY}
             overrideError={(this.props.Confirmed || {}).checked}
             onUpdate={this.updateDate}
             onError={this.handleError}
@@ -160,9 +174,9 @@ export class ApplicantBirthDate extends Subsection {
 ApplicantBirthDate.defaultProps = {
   Date: {},
   Confirmed: {},
-  onUpdate: () => {},
+  onUpdate: () => { },
   onError: (value, arr) => arr,
-  dispatch: () => {},
+  dispatch: () => { },
 }
 
 export default connectSubsection(ApplicantBirthDate, sectionConfig)

--- a/src/components/Section/Identification/ApplicantBirthDate/ApplicantBirthDate.test.jsx
+++ b/src/components/Section/Identification/ApplicantBirthDate/ApplicantBirthDate.test.jsx
@@ -37,7 +37,7 @@ describe('The applicant birth date component', () => {
       Date: {
         month: '01',
         day: '01',
-        year: '1700'
+        year: '2018'
       },
       onUpdate: () => {
         updates++
@@ -51,18 +51,48 @@ describe('The applicant birth date component', () => {
     expect(updates).toBe(4)
   })
 
-  it('displays age confirmation', () => {
+  it('displays age confirmation when age is under 16', () => {
     const expected = {
       name: 'input-focus',
       label: 'Text input focused',
       Date: {
         month: '01',
         day: '01',
-        year: '1700'
+        year: '2018'
       },
       onUpdate: () => {}
     }
     const component = createComponent(expected)
     expect(component.find('.age-warning').length).toBe(1)
+  })
+
+  it('it does not display age confirmation when age is over 15 under 101', () => {
+    const expected = {
+      name: 'input-focus',
+      label: 'Text input focused',
+      Date: {
+        month: '01',
+        day: '01',
+        year: '2000'
+      },
+      onUpdate: () => {}
+    }
+    const component = createComponent(expected)
+    expect(component.find('.age-warning').length).toBe(0)
+  })
+
+  it('it displays age error when age is over 100', () => {
+    const expected = {
+      name: 'input-focus',
+      label: 'Text input focused',
+      Date: {
+        month: '01',
+        day: '01',
+        year: '0001'
+      },
+      onUpdate: () => {}
+    }
+    const component = createComponent(expected)
+    expect(component.find('.usa-alert-heading').length).toBe(1)
   })
 })

--- a/src/components/Section/Relationships/RelationshipStatus/Marital.test.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/Marital.test.jsx
@@ -140,7 +140,7 @@ describe('The relationship status component', () => {
             Recognized: {
               estimated: false,
               day: '1',
-              month: '1',
+              month: '2',
               name: 'Recognized',
               year: '1990',
             },
@@ -212,6 +212,7 @@ describe('The relationship status component', () => {
           .children().length
       ).toEqual(0)
     })
+    
     it('with bad data - where the date divorced is before date entered into civil union', () => {
       const props = {
         ...divorcedDatesSetup,
@@ -225,7 +226,7 @@ describe('The relationship status component', () => {
                   day: '1',
                   month: '1',
                   name: 'DateDivorced',
-                  year: '1950',
+                  year: '1990',
                 },
               },
             },

--- a/src/config/locales/en/error.js
+++ b/src/config/locales/en/error.js
@@ -79,6 +79,21 @@ export const error = {
         'Please confirm the date is correct by checking the box below.'
       ],
       note: '',
+      min: {
+        title: 'The applicant age is not approved',
+        message: [
+          'Your date of birth indicates you are over the age of 100. Please contact your security office representative or the individual who initiated your investigation regarding further instruction.',
+        ],
+        note: '',
+      },
+      max: {
+        title: 'The applicant age is not approved',
+        message: [
+          'Your date of birth indicates you are under the age of 16.',
+          'Please confirm the date is correct by checking the box below.'
+        ],
+        note: '',
+      },
     },
   },
   ssn: {

--- a/src/constants/dateLimits.js
+++ b/src/constants/dateLimits.js
@@ -4,7 +4,7 @@
  */
 import { DateTime } from 'luxon'
 
-const TODAY = DateTime.local()
+export const TODAY = DateTime.local()
 
 export const DEFAULT_LATEST = TODAY
 export const DEFAULT_EARLIEST = TODAY.minus({ years: 200 })

--- a/src/models/sections/__tests__/identificationDateOfBirth.test.js
+++ b/src/models/sections/__tests__/identificationDateOfBirth.test.js
@@ -42,7 +42,7 @@ describe('The identification date of birth section', () => {
       .toEqual(expect.arrayContaining(expectedErrors))
   })
 
-  it('requires a birthdate greater than 16 years', () => {
+  it('requires a confirmation if birthdate less than 16 years', () => {
     const currentYear = new Date().getFullYear()
     const testData = {
       Date: {
@@ -52,7 +52,7 @@ describe('The identification date of birth section', () => {
         estimated: false,
       },
     }
-    const expectedErrors = ['Date.date.date.datetime.DATE_TOO_LATE']
+    const expectedErrors = ["Confirmed.presence.REQUIRED"]
 
     expect(validateModel(testData, identifcationDateOfBirth))
       .toEqual(expect.arrayContaining(expectedErrors))
@@ -78,7 +78,6 @@ describe('The identification date of birth section', () => {
         day: '1',
         year: '2018',
         estimated: false,
-        name: "birthdate",
       },
       Confirmed: {
         checked: true,
@@ -87,7 +86,26 @@ describe('The identification date of birth section', () => {
 
     expect(validateModel(testData, identifcationDateOfBirth)).toBe(true)
   })
+/* TODO validate checked property to ensure it is set to true
+  it('does not allow an age less than 16 birthdate if confirmed not checked', () => {
+    const testData = {
+      Date: {
+        month: '1',
+        day: '1',
+        year: '2018',
+        estimated: false,
+      },
+      Confirmed: {
+        checked: false,
+      }
+    }
 
+    const expectedErrors = ["Date.date.date.datetime.DATE_TOO_LATE"]
+
+    expect(validateModel(testData, identifcationDateOfBirth))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+*/
   it('requires a birthdate less than 100 years and 1 day even if confirmed', () => {
     const testData = {
       Date: {
@@ -95,7 +113,6 @@ describe('The identification date of birth section', () => {
         day: '1',
         year: '1905',
         estimated: false,
-        name: "birthdate",
       },
       Confirmed: {
         checked: true,

--- a/src/models/sections/__tests__/identificationDateOfBirth.test.js
+++ b/src/models/sections/__tests__/identificationDateOfBirth.test.js
@@ -71,21 +71,40 @@ describe('The identification date of birth section', () => {
     expect(validateModel(testData, identifcationDateOfBirth)).toBe(true)
   })
 
-  it('allows an "invalid" birthdate if confirmed', () => {
-    const currentYear = new Date().getFullYear()
+  it('allows an age less than 16 birthdate if confirmed', () => {
     const testData = {
       Date: {
         month: '1',
         day: '1',
-        year: '1900',
+        year: '2018',
         estimated: false,
+        name: "birthdate",
       },
       Confirmed: {
         checked: true,
       }
     }
-    const expectedErrors = ['Date.date.date.datetime.DATE_TOO_LATE']
 
     expect(validateModel(testData, identifcationDateOfBirth)).toBe(true)
   })
+
+  it('requires a birthdate less than 100 years and 1 day even if confirmed', () => {
+    const testData = {
+      Date: {
+        month: '1',
+        day: '1',
+        year: '1905',
+        estimated: false,
+        name: "birthdate",
+      },
+      Confirmed: {
+        checked: true,
+      }
+    }
+    const expectedErrors = ['Date.date.date.datetime.DATE_TOO_EARLY']
+
+    expect(validateModel(testData, identifcationDateOfBirth))
+      .toEqual(expect.arrayContaining(expectedErrors))
+  })
+
 })

--- a/src/models/sections/__tests__/identificationDateOfBirth.test.js
+++ b/src/models/sections/__tests__/identificationDateOfBirth.test.js
@@ -70,4 +70,22 @@ describe('The identification date of birth section', () => {
 
     expect(validateModel(testData, identifcationDateOfBirth)).toBe(true)
   })
+
+  it('allows an "invalid" birthdate if confirmed', () => {
+    const currentYear = new Date().getFullYear()
+    const testData = {
+      Date: {
+        month: '1',
+        day: '1',
+        year: '1900',
+        estimated: false,
+      },
+      Confirmed: {
+        checked: true,
+      }
+    }
+    const expectedErrors = ['Date.date.date.datetime.DATE_TOO_LATE']
+
+    expect(validateModel(testData, identifcationDateOfBirth)).toBe(true)
+  })
 })

--- a/src/models/sections/__tests__/identificationDateOfBirth.test.js
+++ b/src/models/sections/__tests__/identificationDateOfBirth.test.js
@@ -86,7 +86,7 @@ describe('The identification date of birth section', () => {
 
     expect(validateModel(testData, identifcationDateOfBirth)).toBe(true)
   })
-/* TODO validate checked property to ensure it is set to true
+
   it('does not allow an age less than 16 birthdate if confirmed not checked', () => {
     const testData = {
       Date: {
@@ -100,12 +100,12 @@ describe('The identification date of birth section', () => {
       }
     }
 
-    const expectedErrors = ["Date.date.date.datetime.DATE_TOO_LATE"]
+    const expectedErrors = ["Confirmed.model.checked.requireTrue.VALUE_NOT_TRUE"]
 
     expect(validateModel(testData, identifcationDateOfBirth))
       .toEqual(expect.arrayContaining(expectedErrors))
   })
-*/
+
   it('requires a birthdate less than 100 years and 1 day even if confirmed', () => {
     const testData = {
       Date: {

--- a/src/models/sections/identificationDateOfBirth.js
+++ b/src/models/sections/identificationDateOfBirth.js
@@ -1,5 +1,5 @@
 import { SELF } from 'constants/dateLimits'
-import { date } from 'models/shared/date'
+import date from '../../models/shared/date'
 const identificationDateOfBirth = {
   Date: (value, attributes) => {
     return {

--- a/src/models/sections/identificationDateOfBirth.js
+++ b/src/models/sections/identificationDateOfBirth.js
@@ -1,9 +1,18 @@
 import { SELF } from 'constants/dateLimits'
-
+import { date } from 'models/shared/date'
 const identificationDateOfBirth = {
-  Date: {
-    presence: true,
-    date: { ...SELF },
+  Date: (value, attributes) => {
+    return {
+      presence: true,
+      date: {
+        ...SELF,
+        validator: date,
+        confirmed: !!attributes.Confirmed && attributes.Confirmed.checked,
+      },
+    }
+  },
+  Confirmed: {
+    presence: false,
   },
 }
 

--- a/src/models/sections/identificationDateOfBirth.js
+++ b/src/models/sections/identificationDateOfBirth.js
@@ -1,7 +1,6 @@
 import { SELF, TODAY } from 'constants/dateLimits'
 import date from '../../models/shared/date'
 import { DateTime } from 'luxon'
-import requireTrue from '../validators/requireTrue'
 
 const identificationDateOfBirth = {
   Date: (value, attributes) => {
@@ -23,10 +22,15 @@ const identificationDateOfBirth = {
       if (age < 16.0)
         return {
           presence: true,
-          /* TODO validate checked property to ensure it is set to true
-          checked: validator here
-          */
+          model: {
+            validator: {
+              checked: {
+                presence: true,
+                requireTrue: true,
+              }
+            }
           }
+        }
       else
         return {}
     }

--- a/src/models/sections/identificationDateOfBirth.js
+++ b/src/models/sections/identificationDateOfBirth.js
@@ -1,19 +1,37 @@
-import { SELF } from 'constants/dateLimits'
+import { SELF, TODAY } from 'constants/dateLimits'
 import date from '../../models/shared/date'
+import { DateTime } from 'luxon'
+import requireTrue from '../validators/requireTrue'
+
 const identificationDateOfBirth = {
   Date: (value, attributes) => {
     return {
       presence: true,
       date: {
-        ...SELF,
+        earliest: SELF.earliest,
+        latest: !!attributes.Confirmed && attributes.Confirmed.checked ? TODAY : undefined,
         validator: date,
-        confirmed: !!attributes.Confirmed && attributes.Confirmed.checked,
       },
     }
   },
-  Confirmed: {
-    presence: false,
-  },
+  Confirmed: (value, attributes) => {
+    if (attributes.Date) {
+      var d = new Date(`${attributes.Date.month}/${attributes.Date.day}/${attributes.Date.year}`)
+      d.setFullYear(attributes.Date.year)
+      var age = TODAY.diff(DateTime.fromJSDate(d)).as('years')
+
+      if (age < 16.0)
+        return {
+          presence: true,
+          /* TODO validate checked property to ensure it is set to true
+          checked: validator here
+          */
+          }
+      else
+        return {}
+    }
+    return {}
+  }
 }
 
 export default identificationDateOfBirth

--- a/src/models/shared/__tests__/date.test.js
+++ b/src/models/shared/__tests__/date.test.js
@@ -76,6 +76,12 @@ describe('The date model', () => {
       expect(validateModel(testData, date, { ...SELF, ...testRequirements }))
         .toEqual(true)
     })
+
+    it('passes an invalid birthdate if confirmed', () => {
+      const testData = { date: TODAY.minus({ years: 200 }) }
+      expect(validateModel(testData, date, { ...SELF, ...testRequirements, confirmed: true }))
+        .toEqual(true)
+    })
   })
 
   describe('with PARENT birthdate limits', () => {

--- a/src/models/shared/__tests__/date.test.js
+++ b/src/models/shared/__tests__/date.test.js
@@ -76,12 +76,6 @@ describe('The date model', () => {
       expect(validateModel(testData, date, { ...SELF, ...testRequirements }))
         .toEqual(true)
     })
-
-    it('passes an invalid birthdate if confirmed', () => {
-      const testData = { date: TODAY.minus({ years: 200 }) }
-      expect(validateModel(testData, date, { ...SELF, ...testRequirements, confirmed: true }))
-        .toEqual(true)
-    })
   })
 
   describe('with PARENT birthdate limits', () => {

--- a/src/models/shared/date.js
+++ b/src/models/shared/date.js
@@ -17,6 +17,10 @@ const date = {
   date: {
     presence: true,
     datetime: (value, attributes, attributeName, options) => {
+      // return true if confirmed
+      if (options.confirmed)
+        return true
+
       if (options && (options.earliest || options.latest)) {
         const { earliest, latest } = options
         const constraints = {}

--- a/src/models/shared/date.js
+++ b/src/models/shared/date.js
@@ -1,5 +1,3 @@
-import { DateTime, Duration } from 'luxon'
-
 const date = {
   day: (value, attributes, attributeName, options) => (
     options && options.requireDay
@@ -24,22 +22,10 @@ const date = {
         const { earliest, latest } = options
         const constraints = {}
 
-        if (options.confirmed) {
-          //special case for birthdates, only return the max age constraint
-          if (value.name === "birthdate") {
-            if (earliest) constraints.earliest = earliest
+        if (earliest) constraints.earliest = earliest
+        if (latest) constraints.latest = latest
 
-            return constraints
-          }
-
-          return true
-        }
-        else {
-          if (earliest) constraints.earliest = earliest
-          if (latest) constraints.latest = latest
-
-          return constraints
-        }
+        return constraints
       }
 
       return true

--- a/src/models/shared/date.js
+++ b/src/models/shared/date.js
@@ -1,3 +1,5 @@
+import { DateTime, Duration } from 'luxon'
+
 const date = {
   day: (value, attributes, attributeName, options) => (
     options && options.requireDay
@@ -17,18 +19,27 @@ const date = {
   date: {
     presence: true,
     datetime: (value, attributes, attributeName, options) => {
-      // return true if confirmed
-      if (options.confirmed)
-        return true
 
       if (options && (options.earliest || options.latest)) {
         const { earliest, latest } = options
         const constraints = {}
 
-        if (earliest) constraints.earliest = earliest
-        if (latest) constraints.latest = latest
+        if (options.confirmed) {
+          //special case for birthdates, only return the max age constraint
+          if (value.name === "birthdate") {
+            if (earliest) constraints.earliest = earliest
 
-        return constraints
+            return constraints
+          }
+
+          return true
+        }
+        else {
+          if (earliest) constraints.earliest = earliest
+          if (latest) constraints.latest = latest
+
+          return constraints
+        }
       }
 
       return true


### PR DESCRIPTION
## Description
addresses a bug described in slack thread https://gsa-tts.slack.com/archives/C9VSX3JNM/p1568312780370000 thought to be caused by original EN-2383 of changing age limit to 100 in identification date of birth, although I think this bug was present regardless of changing the age limit
\[Replace this with your description, include Fixes #123 to connect to the github issue\]

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
