### PR TITLE
EN-3633 fix birthdate component validation to not

### DIFF
--- a/src/components/Form/DateControl/DateControl.jsx
+++ b/src/components/Form/DateControl/DateControl.jsx
@@ -314,7 +314,7 @@ class DateControl extends ValidationElement {
               ref="year"
               label="Year"
               disabled={this.state.disabled}
-              min={this.props.minDate ? this.props.minDate.year : null}
+              min="1001"
               max={this.props.maxDate ? this.props.maxDate.year : null}
               maxlength="4"
               pattern={this.props.pattern}

--- a/src/components/Form/DateControl/DateControl.jsx
+++ b/src/components/Form/DateControl/DateControl.jsx
@@ -314,8 +314,8 @@ class DateControl extends ValidationElement {
               ref="year"
               label="Year"
               disabled={this.state.disabled}
-              min="1000"
-              max={this.props.maxDate && this.props.maxDate.year}
+              min={this.props.minDate ? this.props.minDate.year : null}
+              max={this.props.maxDate ? this.props.maxDate.year : null}
               maxlength="4"
               pattern={this.props.pattern}
               readonly={this.props.readonly}

--- a/src/components/Form/DateControl/DateControl.jsx
+++ b/src/components/Form/DateControl/DateControl.jsx
@@ -314,7 +314,7 @@ class DateControl extends ValidationElement {
               ref="year"
               label="Year"
               disabled={this.state.disabled}
-              min="1001"
+              min="0"
               max={this.props.maxDate ? this.props.maxDate.year : null}
               maxlength="4"
               pattern={this.props.pattern}

--- a/src/components/Form/Number/Number.jsx
+++ b/src/components/Form/Number/Number.jsx
@@ -9,6 +9,7 @@ export default class Number extends ValidationElement {
     this.state = {
       uid: `${this.props.name}-${super.guid()}`,
       max: props.max,
+      min: props.min,
     }
 
     this.handleError = this.handleError.bind(this)
@@ -19,9 +20,10 @@ export default class Number extends ValidationElement {
       return
     }
 
-    const old = this.state.max
-    this.setState({ max: next.max, value: next.value }, () => {
-      if (old !== next.max) {
+    const oldmax = this.state.max
+    const oldmin = this.state.min
+    this.setState({ max: next.max, min: next.min, value: next.value }, () => {
+      if (oldmax !== next.max || oldmin !== next.min) {
         this.handleValidation(
           {
             fake: true,
@@ -114,6 +116,7 @@ Number.defaultProps = {
   disabled: false,
   value: '',
   max: '',
+  min: '',
   prefix: '',
   pattern: '^(\\s*|\\d+)$',
   errorCode: null,

--- a/src/components/Section/Financial/Taxes/Taxes.test.jsx
+++ b/src/components/Section/Financial/Taxes/Taxes.test.jsx
@@ -136,11 +136,11 @@ describe('The taxes component', () => {
       const component = createComponent(props)
       expect(
         component
-          .find('.error-messages [data-i18n="error.taxesSatisfied.min"]')
+          .find('.error-messages [data-i18n="error.date.year.min"]')
           .text()
       ).toEqual(
-        `${i18n.t('error.taxesSatisfied.min.title')}${i18n.t(
-          'error.taxesSatisfied.min.message'
+        `${i18n.t('error.date.year.min.title')}${i18n.t(
+          'error.date.year.min.message'
         )}`
       )
     })

--- a/src/components/Section/Financial/Taxes/Taxes.test.jsx
+++ b/src/components/Section/Financial/Taxes/Taxes.test.jsx
@@ -124,7 +124,7 @@ describe('The taxes component', () => {
                   estimated: false,
                   month: '1',
                   day: '1',
-                  year: '1970',
+                  year: '1000',
                 },
               },
             },

--- a/src/components/Section/Financial/Taxes/Taxes.test.jsx
+++ b/src/components/Section/Financial/Taxes/Taxes.test.jsx
@@ -136,11 +136,11 @@ describe('The taxes component', () => {
       const component = createComponent(props)
       expect(
         component
-          .find('.error-messages [data-i18n="error.date.year.min"]')
+          .find('.error-messages [data-i18n="error.taxesSatisfied.min"]')
           .text()
       ).toEqual(
-        `${i18n.t('error.date.year.min.title')}${i18n.t(
-          'error.date.year.min.message'
+        `${i18n.t('error.taxesSatisfied.min.title')}${i18n.t(
+          'error.taxesSatisfied.min.message'
         )}`
       )
     })

--- a/src/components/Section/History/dateranges.js
+++ b/src/components/Section/History/dateranges.js
@@ -3,6 +3,7 @@
  * Date object or null.
  */
 export const extractDate = dateObj => {
+  
   if (dateObj instanceof Date) {
     return dateObj
   }
@@ -10,8 +11,10 @@ export const extractDate = dateObj => {
   if (!dateObj || !dateObj.month || !dateObj.day || !dateObj.year) {
     return null
   }
+  var d = new Date(`${dateObj.month}/${dateObj.day}/${dateObj.year}`)
+  d.setFullYear(dateObj.year) // addresses an issue where two digit years are assumed to be in 20th or 21st centry, ex: 99 -> 1999 01 -> 2001
 
-  return new Date(`${dateObj.month}/${dateObj.day}/${dateObj.year}`)
+  return d
 }
 
 /**
@@ -189,7 +192,7 @@ export const validDate = date => {
   const y = parseInt(year || 0)
 
   return (
-    y > 1000 &&
+    y >= 0 &&
     y < 10000 &&
     (m > 0 && m < 13) &&
     (d > 0 && d <= daysInMonth(m, y))

--- a/src/components/Section/History/dateranges.js
+++ b/src/components/Section/History/dateranges.js
@@ -189,7 +189,7 @@ export const validDate = date => {
   }
   const m = parseInt(month || 0)
   const d = parseInt(day || 0)
-  const y = parseInt(year || 0)
+  const y = parseInt(year || -1)
 
   return (
     y >= 0 &&

--- a/src/components/Section/Identification/ApplicantBirthDate/ApplicantBirthDate.jsx
+++ b/src/components/Section/Identification/ApplicantBirthDate/ApplicantBirthDate.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { i18n } from 'config'
-import { DateTime } from 'luxon'
+import { TODAY } from 'constants/dateLimit'
 import {
   Field, DateControl, Show, Checkbox,
 } from 'components/Form'
@@ -170,7 +170,7 @@ export class ApplicantBirthDate extends Subsection {
     )
   }
 }
-const TODAY = DateTime.local()
+
 ApplicantBirthDate.defaultProps = {
   Date: {},
   Confirmed: {},

--- a/src/components/Section/Identification/ApplicantBirthDate/ApplicantBirthDate.jsx
+++ b/src/components/Section/Identification/ApplicantBirthDate/ApplicantBirthDate.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { i18n } from 'config'
-
+import { DateTime } from 'luxon'
 import {
   Field, DateControl, Show, Checkbox,
 } from 'components/Form'
@@ -133,6 +133,8 @@ export class ApplicantBirthDate extends Subsection {
             name="birthdate"
             {...this.props.Date}
             relationship="Self"
+            minDate={TODAY.minus({ years: 100, days: 1 })}
+            maxDate={TODAY.minus({ years: 16 })}
             overrideError={(this.props.Confirmed || {}).checked}
             onUpdate={this.updateDate}
             onError={this.handleError}
@@ -156,7 +158,7 @@ export class ApplicantBirthDate extends Subsection {
     )
   }
 }
-
+const TODAY = DateTime.local()
 ApplicantBirthDate.defaultProps = {
   Date: {},
   Confirmed: {},

--- a/src/components/Section/Identification/ApplicantBirthDate/ApplicantBirthDate.jsx
+++ b/src/components/Section/Identification/ApplicantBirthDate/ApplicantBirthDate.jsx
@@ -134,7 +134,7 @@ export class ApplicantBirthDate extends Subsection {
             {...this.props.Date}
             relationship="Self"
             minDate={TODAY.minus({ years: 100, days: 1 })}
-            maxDate={TODAY.minus({ years: 16 })}
+            maxDate={TODAY}
             overrideError={(this.props.Confirmed || {}).checked}
             onUpdate={this.updateDate}
             onError={this.handleError}

--- a/src/components/Section/Identification/ApplicantBirthDate/ApplicantBirthDate.jsx
+++ b/src/components/Section/Identification/ApplicantBirthDate/ApplicantBirthDate.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { i18n } from 'config'
-import { TODAY } from '../../../../constants/dateLimit'
+import { TODAY } from '../../../../constants/dateLimits'
 import {
   Field, DateControl, Show, Checkbox,
 } from 'components/Form'

--- a/src/components/Section/Identification/ApplicantBirthDate/ApplicantBirthDate.jsx
+++ b/src/components/Section/Identification/ApplicantBirthDate/ApplicantBirthDate.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { i18n } from 'config'
-import { TODAY } from 'constants/dateLimit'
+import { TODAY } from '../../../../constants/dateLimit'
 import {
   Field, DateControl, Show, Checkbox,
 } from 'components/Form'

--- a/src/components/Section/Identification/ApplicantBirthDate/ApplicantBirthDate.jsx
+++ b/src/components/Section/Identification/ApplicantBirthDate/ApplicantBirthDate.jsx
@@ -76,7 +76,7 @@ export class ApplicantBirthDate extends Subsection {
 
     //too old
     const hasMinError = local.some(
-      x => (!x.valid || x.valid === false) && (x.code === 'date.min')
+      x => (x.valid === false) && (x.code === 'date.min')
     )
     
     //too young

--- a/src/components/Section/Identification/ApplicantBirthDate/ApplicantBirthDate.jsx
+++ b/src/components/Section/Identification/ApplicantBirthDate/ApplicantBirthDate.jsx
@@ -73,11 +73,12 @@ export class ApplicantBirthDate extends Subsection {
 
   handleError(value, arr) {
     let local = [...arr]
-    console.log(local)
+
     //too old
     const hasMinError = local.some(
-      x => (x.valid === false) && (x.code === 'date.min')
+      x => (!x.valid || x.valid === false) && (x.code === 'date.min')
     )
+    
     //too young
     const hasMaxError = local.some(
       x => (x.valid === false) && (x.code === 'date.max')

--- a/src/components/Section/Identification/ApplicantBirthDate/ApplicantBirthDate.jsx
+++ b/src/components/Section/Identification/ApplicantBirthDate/ApplicantBirthDate.jsx
@@ -73,25 +73,36 @@ export class ApplicantBirthDate extends Subsection {
 
   handleError(value, arr) {
     let local = [...arr]
-
-    const hasMinMaxError = local.some(
-      x => !x.valid || (x.valid === false && (x.code === 'date.min' || x.code === 'date.max'))
+    console.log(local)
+    //too old
+    const hasMinError = local.some(
+      x => (x.valid === false) && (x.code === 'date.min')
+    )
+    //too young
+    const hasMaxError = local.some(
+      x => (x.valid === false) && (x.code === 'date.max')
     )
 
     let birthdateValid = null
     if (this.props.Confirmed && this.props.Confirmed.checked === true) birthdateValid = true
-    else if (hasMinMaxError) birthdateValid = false
+    else if (hasMinError || hasMaxError) birthdateValid = false
 
     local.push({
-      code: 'birthdate.age',
-      valid: birthdateValid,
+      code: 'birthdate.age.max',
+      valid: !hasMaxError,
+      uid: this.state.uid,
+    })
+
+    local.push({
+      code: 'birthdate.age.min',
+      valid: !hasMinError,
       uid: this.state.uid,
     })
 
     local = local.filter(x => x.code !== 'date.min' && x.code !== 'date.max')
 
     // Store the errors
-    this.setState({ errors: local, needsConfirmation: hasMinMaxError })
+    this.setState({ errors: local, needsConfirmation: hasMaxError })
 
     // Take the original and concatenate our new error values to it
     return super.handleError(value, local)
@@ -99,9 +110,9 @@ export class ApplicantBirthDate extends Subsection {
 
   confirmationError(value) {
     let local = [...this.state.errors] // eslint-disable-line
-    local = local.filter(x => x.code !== 'birthdate.age')
+    local = local.filter(x => x.code !== 'birthdate.age.max')
     local.push({
-      code: 'birthdate.age',
+      code: 'birthdate.age.max',
       valid: value,
       uid: this.state.uid,
     })
@@ -133,7 +144,7 @@ export class ApplicantBirthDate extends Subsection {
             name="birthdate"
             {...this.props.Date}
             relationship="Self"
-            minDate={TODAY.minus({ years: 100, days: 1 })}
+            
             maxDate={TODAY}
             overrideError={(this.props.Confirmed || {}).checked}
             onUpdate={this.updateDate}
@@ -162,9 +173,9 @@ const TODAY = DateTime.local()
 ApplicantBirthDate.defaultProps = {
   Date: {},
   Confirmed: {},
-  onUpdate: () => {},
+  onUpdate: () => { },
   onError: (value, arr) => arr,
-  dispatch: () => {},
+  dispatch: () => { },
 }
 
 export default connectSubsection(ApplicantBirthDate, sectionConfig)

--- a/src/components/Section/Identification/ApplicantBirthDate/ApplicantBirthDate.jsx
+++ b/src/components/Section/Identification/ApplicantBirthDate/ApplicantBirthDate.jsx
@@ -75,7 +75,7 @@ export class ApplicantBirthDate extends Subsection {
     let local = [...arr]
 
     const hasMinMaxError = local.some(
-      x => x.valid === false && (x.code === 'date.min' || x.code === 'date.max')
+      x => !x.valid || (x.valid === false && (x.code === 'date.min' || x.code === 'date.max'))
     )
 
     let birthdateValid = null

--- a/src/components/Section/Identification/ApplicantBirthDate/ApplicantBirthDate.test.jsx
+++ b/src/components/Section/Identification/ApplicantBirthDate/ApplicantBirthDate.test.jsx
@@ -51,7 +51,7 @@ describe('The applicant birth date component', () => {
     expect(updates).toBe(4)
   })
 
-  it('displays age confirmation', () => {
+  it('displays age confirmation when age is under 16', () => {
     const expected = {
       name: 'input-focus',
       label: 'Text input focused',
@@ -64,5 +64,35 @@ describe('The applicant birth date component', () => {
     }
     const component = createComponent(expected)
     expect(component.find('.age-warning').length).toBe(1)
+  })
+
+  it('it does not display age confirmation when age is over 15 under 101', () => {
+    const expected = {
+      name: 'input-focus',
+      label: 'Text input focused',
+      Date: {
+        month: '01',
+        day: '01',
+        year: '2000'
+      },
+      onUpdate: () => {}
+    }
+    const component = createComponent(expected)
+    expect(component.find('.age-warning').length).toBe(0)
+  })
+
+  it('it displays age error when age is over 100', () => {
+    const expected = {
+      name: 'input-focus',
+      label: 'Text input focused',
+      Date: {
+        month: '01',
+        day: '01',
+        year: '0001'
+      },
+      onUpdate: () => {}
+    }
+    const component = createComponent(expected)
+    expect(component.find('.usa-alert-heading').length).toBe(1)
   })
 })

--- a/src/components/Section/Identification/ApplicantBirthDate/ApplicantBirthDate.test.jsx
+++ b/src/components/Section/Identification/ApplicantBirthDate/ApplicantBirthDate.test.jsx
@@ -37,7 +37,7 @@ describe('The applicant birth date component', () => {
       Date: {
         month: '01',
         day: '01',
-        year: '1700'
+        year: '2018'
       },
       onUpdate: () => {
         updates++
@@ -58,7 +58,7 @@ describe('The applicant birth date component', () => {
       Date: {
         month: '01',
         day: '01',
-        year: '1700'
+        year: '2018'
       },
       onUpdate: () => {}
     }

--- a/src/components/Section/Relationships/RelationshipStatus/Marital.test.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/Marital.test.jsx
@@ -260,7 +260,7 @@ describe('The relationship status component', () => {
                   day: '1',
                   month: '1',
                   name: 'DateDivorced',
-                  year: '1950',
+                  year: '1000',
                 },
               },
             },

--- a/src/components/Section/Relationships/RelationshipStatus/Marital.test.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/Marital.test.jsx
@@ -246,39 +246,5 @@ describe('The relationship status component', () => {
         )}`
       )
     })
-
-    it('with bad data - where the year divorced is before the year entered into civil union', () => {
-      const props = {
-        ...divorcedDatesSetup,
-        DivorcedList: {
-          items: [
-            {
-              Item: {
-                ...divorcedDatesSetup.DivorcedList.items[0].Item,
-                DateDivorced: {
-                  estimated: false,
-                  day: '1',
-                  month: '1',
-                  name: 'DateDivorced',
-                  year: '1000',
-                },
-              },
-            },
-          ],
-        },
-        valid: false,
-      }
-
-      const component = createComponent(props)
-      expect(
-        component
-          .find('.error-messages [data-i18n="error.date.year.min"]')
-          .text()
-      ).toEqual(
-        `${i18n.t('error.date.year.min.title')}${i18n.t(
-          'error.date.year.min.message'
-        )}`
-      )
-    })
   })
 })

--- a/src/components/Section/Relationships/RelationshipStatus/Marital.test.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/Marital.test.jsx
@@ -140,7 +140,7 @@ describe('The relationship status component', () => {
             Recognized: {
               estimated: false,
               day: '1',
-              month: '1',
+              month: '2',
               name: 'Recognized',
               year: '1990',
             },
@@ -212,7 +212,42 @@ describe('The relationship status component', () => {
           .children().length
       ).toEqual(0)
     })
+    
     it('with bad data - where the date divorced is before date entered into civil union', () => {
+      const props = {
+        ...divorcedDatesSetup,
+        DivorcedList: {
+          items: [
+            {
+              Item: {
+                ...divorcedDatesSetup.DivorcedList.items[0].Item,
+                DateDivorced: {
+                  estimated: false,
+                  day: '1',
+                  month: '1',
+                  name: 'DateDivorced',
+                  year: '1990',
+                },
+              },
+            },
+          ],
+        },
+        valid: false,
+      }
+
+      const component = createComponent(props)
+      expect(
+        component
+          .find('.error-messages [data-i18n="error.divorceDate.min"]')
+          .text()
+      ).toEqual(
+        `${i18n.t('error.divorceDate.min.title')}${i18n.t(
+          'error.divorceDate.min.message'
+        )}`
+      )
+    })
+
+    it('with bad data - where the year divorced is before the year entered into civil union', () => {
       const props = {
         ...divorcedDatesSetup,
         DivorcedList: {
@@ -237,11 +272,11 @@ describe('The relationship status component', () => {
       const component = createComponent(props)
       expect(
         component
-          .find('.error-messages [data-i18n="error.divorceDate.min"]')
+          .find('.error-messages [data-i18n="error.date.year.min"]')
           .text()
       ).toEqual(
-        `${i18n.t('error.divorceDate.min.title')}${i18n.t(
-          'error.divorceDate.min.message'
+        `${i18n.t('error.date.year.min.title')}${i18n.t(
+          'error.date.year.min.message'
         )}`
       )
     })

--- a/src/config/locales/en/error.js
+++ b/src/config/locales/en/error.js
@@ -79,6 +79,21 @@ export const error = {
         'Please confirm the date is correct by checking the box below.'
       ],
       note: '',
+      min: {
+        title: 'The applicant age is not approved',
+        message: [
+          'Your date of birth indicates you are over the age of 100.',
+        ],
+        note: '',
+      },
+      max: {
+        title: 'The applicant age is not approved',
+        message: [
+          'Your date of birth indicates you are under the age of 16.',
+          'Please confirm the date is correct by checking the box below.'
+        ],
+        note: '',
+      },
     },
   },
   ssn: {

--- a/src/config/locales/en/error.js
+++ b/src/config/locales/en/error.js
@@ -82,7 +82,7 @@ export const error = {
       min: {
         title: 'The applicant age is not approved',
         message: [
-          'Your date of birth indicates you are over the age of 100.',
+          'Your date of birth indicates you are over the age of 100. Please contact your security office representative or the individual who initiated your investigation regarding further instruction.',
         ],
         note: '',
       },

--- a/src/constants/dateLimits.js
+++ b/src/constants/dateLimits.js
@@ -4,7 +4,7 @@
  */
 import { DateTime } from 'luxon'
 
-const TODAY = DateTime.local()
+export const TODAY = DateTime.local()
 
 export const DEFAULT_LATEST = TODAY
 export const DEFAULT_EARLIEST = TODAY.minus({ years: 200 })


### PR DESCRIPTION
## Description

addresses a bug where component validation allows '1000' to be entered in the identification date of birth year

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
