### PR TITLE
Modified the clear command so it wouldn't effect the country string f…

### DIFF
--- a/src/components/Section/Relationships/RelationshipStatus/Cohabitant.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/Cohabitant.jsx
@@ -58,7 +58,7 @@ export default class Cohabitant extends ValidationElement {
     const state = {
       Name: {},
       Birthdate: null,
-      BirthPlace: null,
+      BirthPlace: {country: undefined},
       ForeignBornDocument: null,
       SSN: null,
       OtherNames: null,
@@ -74,9 +74,6 @@ export default class Cohabitant extends ValidationElement {
   }
 
   updateName(values) {
-    if (this.props.SameSpouseConfirmed) {
-      return
-    }
 
     const similarSpouse = this.hasSimilarSpouse(values)
 

--- a/src/components/Section/Relationships/RelationshipStatus/Cohabitant.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/Cohabitant.jsx
@@ -58,7 +58,7 @@ export default class Cohabitant extends ValidationElement {
     const state = {
       Name: {},
       Birthdate: null,
-      BirthPlace: {country: undefined},
+      BirthPlace: {},
       ForeignBornDocument: null,
       SSN: null,
       OtherNames: null,


### PR DESCRIPTION
…unction and removed the return from the update name function that ignored user input

This branch fixed the bug on the cohabitant page that would through an error when the "This is my spouse" button was clicked when the cohabitant had the same name as the users spouse/ Additionally when the "This is not my spouse button was clicked the user was no longer allowed to change the cohabitants name .

\[Replace this with your description, include Fixes #123 to connect to the github issue\]

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
