### PR TITLE
Remove formType query parameter for formType testing

### DIFF
--- a/src/sagas/api.js
+++ b/src/sagas/api.js
@@ -1,9 +1,6 @@
 import {
   takeLatest, put, all, call,
 } from 'redux-saga/effects'
-import queryString from 'query-string'
-
-import { env } from 'config'
 
 import { api } from 'services/api'
 import * as actionTypes from 'constants/actionTypes'
@@ -33,15 +30,6 @@ export function* fetchStatus() {
 export function* login({ username, password }) {
   try {
     const response = yield call(api.login, username, password)
-
-    // for testing with query params
-    if (env.IsDevelopment() || env.IsStaging()) {
-      const params = window.location.search
-      const query = queryString.parse(params)
-
-      if (query.formType) window.formType = query.formType
-      if (query.status) window.status = query.status.toUpperCase()
-    }
 
     yield put(handleLoginSuccess(response))
   } catch (error) {

--- a/src/sagas/form.js
+++ b/src/sagas/form.js
@@ -50,7 +50,7 @@ export function* updateSectionDataLegacy(name, data) {
 export function* setFormData(data) {
   try {
     const { Metadata = {} } = data
-    const formType = window.formType ? window.formType : Metadata.form_type
+    const formType = Metadata.form_type
     const formVersion = Metadata.form_version
 
     yield put(updateApplication('Settings', 'formType', formType))


### PR DESCRIPTION
## Description
With recent developments, query parameters are no longer working and cannot be used for testing. They were mainly used for `?formType=[FORM_TYPE]` to set an applicant's form type.

Developers can set the applicant's from type by using the [sftype](https://github.com/18F/culper/blob/develop/docs/dev-tools.md#sftype----set-the-form-type-and-version-for-a-given-user) tool

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
