### PR TITLE
[EN-3897] Disable ToggleableLocation buttons when it is disabled

### DIFF
--- a/src/components/Form/Location/ToggleableLocation.jsx
+++ b/src/components/Form/Location/ToggleableLocation.jsx
@@ -326,6 +326,7 @@ export default class ToggleableLocation extends ValidationElement {
           required={this.props.required}
           yesLabel={i18n.m('address.options.us.label')}
           value={branchValue(this.props.country)}
+          disabled={this.props.disabled}
         />
         <Show when={this.addressType() === 'United States'}>
           {domesticFields}


### PR DESCRIPTION
## Description
In `Marital`, there is a question: `If legally separated, provide the location of the record.
` that has a `Not applicable` button. When the `Not applicable` button is clicked, the applicant still has the ability to toggle whether the location is `In the U.S.` or `Outside the U.S.`.

This shouldn't be allowed if `Not applicable` is selected. This PR will "grey out" and disable the toggling branch if the location is `Not applicable`.
## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
