### PR TITLE
Rename e-QIP-prototype to culper

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,14 +10,14 @@ If you have any questions or want to read more, check out the [18F Open Source P
 
 ## Where to contribute?
 
-During the development process the development fork of the project will be hosted at [18F/e-QIP-prototype](https://github.com/18F/e-QIP-prototype). This may cause some confusion so we have outlined some basic steps for contributing:
+During the development process the development fork of the project will be hosted at [18F/culper](https://github.com/18F/culper). This may cause some confusion so we have outlined some basic steps for contributing:
 
 1. Go through the [development setup](../README.md#development)
 1. Fork the code on Github
 1. Add a **git remote** with `git remote add fork <path/to/forked/repository>`
 1. Make changes and commit them locally
 1. Push to **fork** using `git push fork`
-1. Create a **pull request** from the forked repository to the [18F/e-QIP-prototype](https://github.com/18F/e-QIP-prototype) repository
+1. Create a **pull request** from the forked repository to the [18F/culper](https://github.com/18F/culper) repository
 
 ## Public domain
 

--- a/api/templates/application.xml
+++ b/api/templates/application.xml
@@ -30,7 +30,7 @@
             <UserPreferences Version="1" Type="Pooled" LastSummaryID="201" LastDynamicListID="201">
               <DisplayNavigation/>
             </UserPreferences>
-            <!-- TODO https://github.com/18F/e-QIP-prototype/issues/759 -->
+            <!-- TODO https://github.com/18F/culper/issues/759 -->
             <ValidationResponses Version="1" Type="FormInstanceSpecific" />
           </FormInstanceSpecific>
           <Pooled>

--- a/api/templates/legal-police-additional-offenses.xml
+++ b/api/templates/legal-police-additional-offenses.xml
@@ -12,7 +12,7 @@
       </AwaitingTrial>
       <Charges>
         <!-- XXX We don't collect more than one -->
-        <!-- See https://github.com/18F/e-QIP-prototype/issues/782 -->
+        <!-- See https://github.com/18F/culper/issues/782 -->
         <Charge ID="1">
           <Charge>{{text $Item.CourtCharge}}</Charge>
           <Date Type="{{dateEstimated $Item.CourtDate}}">

--- a/api/templates/legal-police-offenses.xml
+++ b/api/templates/legal-police-offenses.xml
@@ -11,7 +11,7 @@
         {{if branch $Item.WasCharged | eq "Yes"}}
         <Charges>
           <!-- XXX We don't collect more than one -->
-          <!-- See https://github.com/18F/e-QIP-prototype/issues/782 -->
+          <!-- See https://github.com/18F/culper/issues/782 -->
           <Charge ID="1">
             <Charge>{{text $Item.CourtCharge}}</Charge>
             <Date Type="{{dateEstimated $Item.CourtDate}}">

--- a/api/templates/spouse-former.xml
+++ b/api/templates/spouse-former.xml
@@ -10,7 +10,7 @@
         {{date $Item.Birthdate}}
       </Date>
       <Place>
-        <!-- XXX Work-around for https://github.com/18F/e-QIP-prototype/issues/811 -->
+        <!-- XXX Work-around for https://github.com/18F/culper/issues/811 -->
         {{locationOverrideLayout $Item.BirthPlace "Birthplace without County"}}
       </Place>
     </Birth>
@@ -45,7 +45,7 @@
       </Date>
       {{if or (text $Item.Status | eq "Divorced") (text $Item.Status | eq "Annulled") }}
       <DivorceRecordLocation>
-        <!-- XXX Placeholder text as work-around for https://github.com/18F/e-QIP-prototype/issues/808 -->
+        <!-- XXX Placeholder text as work-around for https://github.com/18F//issues/808 -->
         <Place>
           {{locationOverrideLayout $Item.DivorceLocation "US City, State, Zipcode International city"}}
         </Place>

--- a/api/templates/spouse-former.xml
+++ b/api/templates/spouse-former.xml
@@ -45,7 +45,7 @@
       </Date>
       {{if or (text $Item.Status | eq "Divorced") (text $Item.Status | eq "Annulled") }}
       <DivorceRecordLocation>
-        <!-- XXX Placeholder text as work-around for https://github.com/18F//issues/808 -->
+        <!-- XXX Placeholder text as work-around for https://github.com/18F/culper/issues/808 -->
         <Place>
           {{locationOverrideLayout $Item.DivorceLocation "US City, State, Zipcode International city"}}
         </Place>

--- a/docs/test-scenarios.md
+++ b/docs/test-scenarios.md
@@ -86,8 +86,8 @@ It should be noted that in general, the SF-86 PDF form, the OPM validation matri
 Some e-QIP terminology knowledge is useful when interacting with the e-QIP web service:
 
 * eApp collects form data for an *incoming investigation request*.
-* Requests are sent to e-QIP by a *submitting agency*; i.e., the government agency making the web service call (the "caller"). See `WS_CALLERINFO*` [configuration variables](https://github.com/18F/e-QIP-prototype/blob/develop/docs/CONFIGURATION.md) in eApp.
-* Requests are directed to a particular *investigation service provider (ISP)* and *group*. See `WS_AGENCY*` [configuration variables](https://github.com/18F/e-QIP-prototype/blob/develop/docs/CONFIGURATION.md) in eApp.
+* Requests are sent to e-QIP by a *submitting agency*; i.e., the government agency making the web service call (the "caller"). See `WS_CALLERINFO*` [configuration variables](https://github.com/18F/culper/blob/develop/docs/CONFIGURATION.md) in eApp.
+* Requests are directed to a particular *investigation service provider (ISP)* and *group*. See `WS_AGENCY*` [configuration variables](https://github.com/18F/culper/blob/develop/docs/CONFIGURATION.md) in eApp.
 
 ### `submit` tool
 
@@ -95,13 +95,13 @@ To submit SF-86 XML to the e-QIP test service, use the `api/bin/submit` tool fro
 
 `submit` requires that the following environment variables be set in its execution environment:
 
-* [WS_URL](https://github.com/18F/e-QIP-prototype/blob/develop/docs/CONFIGURATION.md#ws_url)
-* [WS_KEY](https://github.com/18F/e-QIP-prototype/blob/develop/docs/CONFIGURATION.md#ws_key)
-* [WS_CALLERINFO_AGENCY_ID](https://github.com/18F/e-QIP-prototype/blob/develop/docs/CONFIGURATION.md#ws_callerinfo_agency_id)
-* [WS_CALLERINFO_AGENCY_USER_SSN](https://github.com/18F/e-QIP-prototype/blob/develop/docs/CONFIGURATION.md#ws_callerinfo_agency_user_ssn)
-* [WS_CALLERINFO_AGENCY_USER_PSEUDOSSN](https://github.com/18F/e-QIP-prototype/blob/develop/docs/CONFIGURATION.md#ws_callerinfo_agency_user_pseudossn)
-* [WS_AGENCY_ID](https://github.com/18F/e-QIP-prototype/blob/develop/docs/CONFIGURATION.md#ws_agency_id)
-* [WS_AGENCY_GROUP_ID](https://github.com/18F/e-QIP-prototype/blob/develop/docs/CONFIGURATION.md#ws_agency_group_id)
+* [WS_URL](https://github.com/18F/culper/blob/develop/docs/CONFIGURATION.md#ws_url)
+* [WS_KEY](https://github.com/18F/culper/blob/develop/docs/CONFIGURATION.md#ws_key)
+* [WS_CALLERINFO_AGENCY_ID](https://github.com/18F/culper/blob/develop/docs/CONFIGURATION.md#ws_callerinfo_agency_id)
+* [WS_CALLERINFO_AGENCY_USER_SSN](https://github.com/18F/culper/blob/develop/docs/CONFIGURATION.md#ws_callerinfo_agency_user_ssn)
+* [WS_CALLERINFO_AGENCY_USER_PSEUDOSSN](https://github.com/18F/culper/blob/develop/docs/CONFIGURATION.md#ws_callerinfo_agency_user_pseudossn)
+* [WS_AGENCY_ID](https://github.com/18F/culper/blob/develop/docs/CONFIGURATION.md#ws_agency_id)
+* [WS_AGENCY_GROUP_ID](https://github.com/18F/culper/blob/develop/docs/CONFIGURATION.md#ws_agency_group_id)
 
 For our purposes, `WS_CALLERINFO_AGENCY_USER_PSEUDOSSN` must always be set to `0`. For appropriate values for the other configuration settings, plus network requirements for access, see:
 https://docs.google.com/document/d/1q8uvcc4S9gql4cr8LEJt5wy36Db75e37qzpzJYyGi-w

--- a/docs/updating-api-db.md
+++ b/docs/updating-api-db.md
@@ -12,7 +12,7 @@ Before updating the database and API, make sure that the frontend is handling th
 
 ## Update schema
 
-The frontend has a schema that is used to translate the data coming from, and going into, the database. Without properly representing the data in the schema, it will not populate properly when the app is initially loaded. Find the section in question within `/src/schema/section` and add the new input's name, and input type. Input type will correspond with the component used within React (`daterange`, `text`, `location`, etc). Update corresponding schema tests to account for the new addition. See here for an example of this change: https://github.com/18F/e-QIP-prototype/pull/675/files#diff-553dcd0197b047cac66e517b87577db6
+The frontend has a schema that is used to translate the data coming from, and going into, the database. Without properly representing the data in the schema, it will not populate properly when the app is initially loaded. Find the section in question within `/src/schema/section` and add the new input's name, and input type. Input type will correspond with the component used within React (`daterange`, `text`, `location`, etc). Update corresponding schema tests to account for the new addition. See here for an example of this change: https://github.com/18F/culper/pull/675/files#diff-553dcd0197b047cac66e517b87577db6
 
 ## Update database
 
@@ -22,17 +22,17 @@ If the column for the data does not currently exist in the database, it needs to
 date +%Y%m%d%H%M%S
 ```
 
-Following the pattern shown in previous migrations, alter the existing table to add the new column (using snake case for the name of the column). See here for an example of adding a new column to an existing table: https://github.com/18F/e-QIP-prototype/pull/675/files#diff-9fe41306637d1dbea2da5c055ea410b5
+Following the pattern shown in previous migrations, alter the existing table to add the new column (using snake case for the name of the column). See here for an example of adding a new column to an existing table: https://github.com/18F/culper/pull/675/files#diff-9fe41306637d1dbea2da5c055ea410b5
 
 ## Add API boilerplate code
 
-Next, update the API code to include the new data. In most cases this will involve modifying the corresponding section's Go file in the root `/api` folder. Following the existing patterns, copy and paste the boilerplate code within the various functions in the file (code will be added in roughly ~10 different locations). Take care to follow proper naming styles and reference the proper input type (`DateControl`, `Location`, `Email`, etc). See here for an example of adding a new field to an existing section: https://github.com/18F/e-QIP-prototype/pull/675/files#diff-89cd2ccde37e50062861c1ebdc3b539e
+Next, update the API code to include the new data. In most cases this will involve modifying the corresponding section's Go file in the root `/api` folder. Following the existing patterns, copy and paste the boilerplate code within the various functions in the file (code will be added in roughly ~10 different locations). Take care to follow proper naming styles and reference the proper input type (`DateControl`, `Location`, `Email`, etc). See here for an example of adding a new field to an existing section: https://github.com/18F/culper/pull/675/files#diff-89cd2ccde37e50062861c1ebdc3b539e
 
 ## Update XML template and test data
 
 After finding the corresponding XML file in `/api/templates`, make sure that the data is properly represented within the XML. It is also important to make sure that the new input is added to the corresponding `.json` file found within `/api/testdata` which is used to test the generated XML.
 
-Lastly, if the new data is not already found in at least one of the complete scenarios (in `/api/testdata/complete-scenarios`), then update test case 6 to include the data. This will allow the data to be pre-loaded and tested using the [load-scenario](https://github.com/18F/e-QIP-prototype/blob/develop/docs/test-scenarios.md#loading-existing-test-json-files) script.
+Lastly, if the new data is not already found in at least one of the complete scenarios (in `/api/testdata/complete-scenarios`), then update test case 6 to include the data. This will allow the data to be pre-loaded and tested using the [load-scenario](https://github.com/18F/culper/blob/develop/docs/test-scenarios.md#loading-existing-test-json-files) script.
 
 ## Test the change
 
@@ -46,4 +46,4 @@ If the data is still not present after logging out and back in, check the server
 
 ## Example
 
-For reference, the following pull request is a good representation of most of the steps documented above: https://github.com/18F/e-QIP-prototype/pull/675
+For reference, the following pull request is a good representation of most of the steps documented above: https://github.com/18F/culper/pull/675

--- a/src/index.html
+++ b/src/index.html
@@ -85,7 +85,7 @@
           <p class="usa-alert-text">
             In order to view the full content of this site, please use a browser
             with JavaScript enabled. If you cannot, please
-            <a href="https://github.com/18F/e-QIP-prototype/issues/new"
+            <a href="https://github.com/18F/culper/issues/new"
               >file an issue on GitHub</a
             >.
           </p>


### PR DESCRIPTION
## Description
This PR does some cleanup for the name change from `e-QIP-prototype` to `culper`.

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
