### PR TITLE
[EN-3977] Pass foreign born doc flag to Relative component

### DIFF
--- a/src/components/Section/Relationships/Relatives/Relatives.jsx
+++ b/src/components/Section/Relationships/Relatives/Relatives.jsx
@@ -111,6 +111,7 @@ export class Relatives extends Subsection {
   render() {
     const {
       List,
+      requireRelationshipRelativesForeignBornDoc,
       requireRelationshipRelativesUSResidenceDoc,
       requireRelationshipRelativesForeignGovtAffExplanation,
       errors,
@@ -166,6 +167,7 @@ export class Relatives extends Subsection {
             bind={true}
             scrollIntoView={this.props.scrollIntoView}
             required={this.props.required}
+            requireRelationshipRelativesForeignBornDoc={requireRelationshipRelativesForeignBornDoc}
             requireRelationshipRelativesForeignGovtAffExplanation={
               requireRelationshipRelativesForeignGovtAffExplanation}
             requireRelationshipRelativesUSResidenceDoc={requireRelationshipRelativesUSResidenceDoc}


### PR DESCRIPTION
## Description

Fixes bug where the foreign born doc fields were not displayed in the Relative component.

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
