### PR TITLE
[EN-3976] Fix page load citizenship status valid bug

### DIFF
--- a/src/sagas/form.js
+++ b/src/sagas/form.js
@@ -79,11 +79,27 @@ export const updateSectionData = (prevData, field, data) => ({
 // Loop through all form sections and re-validate with the existing data
 export function* handleValidateForm() {
   const formType = yield select(formTypeSelector)
+
+  const applicantBirthdate = yield select(selectApplicantBirthdate)
+  const maritalStatus = yield select(selectMaritalStatus)
+  const hasValidUSPassport = yield select(selectValidUSPassport)
+  // pass any x-section form data required to validate here
+  const validationOptions = {
+    applicantBirthdate,
+    maritalStatus,
+    ...hasValidUSPassport,
+  }
+
   const formData = yield select(selectForm)
+
   yield all(Object.keys(formData)
     .map((key) => {
       const sectionData = formData[key].data
-      const errors = validateSection({ key, data: sectionData }, formType)
+      const errors = validateSection({
+        key,
+        data: sectionData,
+        options: validationOptions,
+      }, formType)
       const newFormSection = {
         data: sectionData,
         errors: errors === true ? [] : errors,

--- a/src/sagas/form.test.js
+++ b/src/sagas/form.test.js
@@ -180,8 +180,23 @@ describe('The handleValidateForm saga', () => {
       .toEqual(select(formTypeSelector))
   })
 
+  it('selects the applicant birthdate from state', () => {
+    expect(generator.next('SF-86').value)
+      .toEqual(select(selectApplicantBirthdate))
+  })
+
+  it('selects the applicant’s marital status from state', () => {
+    expect(generator.next({ month: 5, day: 16, year: 1988 }).value)
+      .toEqual(select(selectMaritalStatus))
+  })
+
+  it('selects the applicant’s US passport status from state', () => {
+    expect(generator.next('Married').value)
+      .toEqual(select(selectValidUSPassport))
+  })
+
   it('selects all form data from state', () => {
-    expect(generator.next('SF86').value)
+    expect(generator.next({ hasValidUSPassport: false }).value)
       .toEqual(select(selectForm))
   })
 


### PR DESCRIPTION
## Description

Make sure to pass cross section form validation options when validation form on page load. This fixes an issue where a user with a valid US passport and valid born abroad citizenship data does not show as valid on page load.

## Checklist for Reviewer

- [ ] Review code changes
- [ ] Review changes for Database effects
- [ ] Verify change works in IE browser

More details about this can be found in [docs/review.md](docs/review.md)
